### PR TITLE
ci: fix commitlint setup errors

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -9,11 +9,19 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: latest
+          run_install: false
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: latest
+          cache: "pnpm"
       - name: Install missing packages and dependencies
-        shell: sh
         run: |
-          curl -fsSL https://get.pnpm.io/install.sh | sh -
-          pnpm add
+          pnpm install
       - name: Validate current commit (last commit) with commitlint
         if: github.event_name == 'push'
         run: pnpm dlx commitlint --last --verbose


### PR DESCRIPTION
This pull request fixes the errors induced by wrong placement of `commitlint.yml` and missing installation scripts for `pnpm` and `node`.