### PR TITLE
feat(frontend): add `StudentCouncil` model for valibot

### DIFF
--- a/website-frontend/src/lib/models/schema.ts
+++ b/website-frontend/src/lib/models/schema.ts
@@ -1,10 +1,12 @@
 import { object, type InferOutput } from 'valibot';
 import { Events } from './event';
 import { Global } from './global';
+import { StudentCouncil } from './student_council';
 
 export const Schema = object({
 	global: Global,
-	events: Events
+	events: Events,
+	student_council: StudentCouncil
 });
 
 export type Schema = InferOutput<typeof Schema>;

--- a/website-frontend/src/lib/models/student_council.ts
+++ b/website-frontend/src/lib/models/student_council.ts
@@ -1,0 +1,7 @@
+import { object, string, type InferOutput } from 'valibot';
+
+export const StudentCouncil = object({
+	flexible_content: string()
+});
+
+export type StudentCouncil = InferOutput<typeof StudentCouncil>;

--- a/website-frontend/src/lib/models/student_council.ts
+++ b/website-frontend/src/lib/models/student_council.ts
@@ -1,7 +1,8 @@
-import { object, string, type InferOutput } from 'valibot';
+import { cleanHtml } from '$lib/models-helpers';
+import { object, pipe, string, type InferOutput } from 'valibot';
 
 export const StudentCouncil = object({
-	flexible_content: string()
+	flexible_content: pipe(string(), cleanHtml)
 });
 
 export type StudentCouncil = InferOutput<typeof StudentCouncil>;

--- a/website-frontend/src/routes/+page.ts
+++ b/website-frontend/src/routes/+page.ts
@@ -2,12 +2,14 @@
 import getDirectusInstance from '$lib/directus';
 import { Global } from '$lib/models/global';
 import { Events } from '$lib/models/event';
+import { StudentCouncil } from '$lib/models/student_council.js';
 import { readItems, readSingleton } from '@directus/sdk';
 import { parse } from 'valibot';
 export async function load({ fetch }) {
 	const directus = getDirectusInstance(fetch);
 	return {
 		global: parse(Global, await directus.request(readSingleton('global'))),
-		events: parse(Events, await directus.request(readItems('events')))
+		events: parse(Events, await directus.request(readItems('events'))),
+		student_council: parse(StudentCouncil, await directus.request(readSingleton('student_council')))
 	};
 }


### PR DESCRIPTION
This PR adds the `StudentCouncil` model for valibot validation in the frontend, with respect to the resolved Student Council collection in the CMS.