### PR TITLE
ci: add code quality check

### DIFF
--- a/.github/workflows/codequality.yml
+++ b/.github/workflows/codequality.yml
@@ -14,8 +14,11 @@ jobs:
       - name: Install dependencies
         run: npm install -g pnpm && pnpm install
       - name: Run Prettier Check
+        if: ${{ !cancelled() }}
         run: pnpm run lint:prettier-only
       - name: Run ESLint
+        if: ${{ !cancelled() }}
         run: pnpm run lint:eslint-only
       - name: Run Svelte checker
+        if: ${{ !cancelled() }}
         run: pnpm run check

--- a/.github/workflows/codequality.yml
+++ b/.github/workflows/codequality.yml
@@ -1,5 +1,7 @@
 name: Check Code Quality
 on: [push, pull_request]
+env:
+  PUBLIC_APIURL: ${{ vars.PUBLIC_APIURL }}
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/codequality.yml
+++ b/.github/workflows/codequality.yml
@@ -13,7 +13,9 @@ jobs:
           node-version: lts/*
       - name: Install dependencies
         run: npm install -g pnpm && pnpm install
+      - name: Run Prettier Check
+        run: pnpm run lint:prettier-only
       - name: Run ESLint
-        run: pnpm run lint
+        run: pnpm run lint:eslint-only
       - name: Run Svelte checker
         run: pnpm run check

--- a/.github/workflows/codequality.yml
+++ b/.github/workflows/codequality.yml
@@ -1,0 +1,19 @@
+name: Check Code Quality
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./website-frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+      - name: Install dependencies
+        run: npm install -g pnpm && pnpm install
+      - name: Run ESLint
+        run: pnpm run lint
+      - name: Run Svelte checker
+        run: pnpm run check

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,7 +1,5 @@
 name: Commit Linter
-
 on: [push, pull_request]
-
 jobs:
   commitlint:
     runs-on: ubuntu-latest

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,5 +1,7 @@
 name: Playwright Tests
 on: [push, pull_request]
+env:
+  PUBLIC_APIURL: ${{ vars.PUBLIC_APIURL }}
 jobs:
   test:
     timeout-minutes: 60
@@ -18,8 +20,6 @@ jobs:
         run: pnpm exec playwright install --with-deps
       - name: Run Playwright tests
         run: pnpm exec playwright test
-        env:
-          PUBLIC_APIURL: ${{ vars.PUBLIC_APIURL }}
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:

--- a/website-frontend/package.json
+++ b/website-frontend/package.json
@@ -9,6 +9,8 @@
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"lint": "prettier --check . && eslint .",
+		"lint:prettier-only": "prettier --check",
+		"lint:eslint-only": "eslint .",
 		"format": "prettier --write .",
 		"test": "pnpm exec playwright test"
 	},

--- a/website-frontend/package.json
+++ b/website-frontend/package.json
@@ -9,7 +9,7 @@
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"lint": "prettier --check . && eslint .",
-		"lint:prettier-only": "prettier --check",
+		"lint:prettier-only": "prettier --check .",
 		"lint:eslint-only": "eslint .",
 		"format": "prettier --write .",
 		"test": "pnpm exec playwright test"


### PR DESCRIPTION
This PR adds code quality checks in the frontend, enforcing the use of Prettier and ESLint checks. This PR also incorporates `svelte-check` for Svelte components diagnostics.

This PR also creates two separate `pnpm` scripts, mainly `lint:prettier-only` and `lint:eslint-only`, for finer granularity in GitHub workflow reports.