### PR TITLE
ci: elevate test workflow access for `vars`

### DIFF
--- a/.github/workflows/codequality.yml
+++ b/.github/workflows/codequality.yml
@@ -33,3 +33,5 @@ jobs:
       - name: Run Svelte check
         if: ${{ !cancelled() }}
         run: pnpm run check
+        env:
+          PUBLIC_APIURL: ${{ vars.PUBLIC_APIURL }}

--- a/.github/workflows/codequality.yml
+++ b/.github/workflows/codequality.yml
@@ -1,5 +1,5 @@
 name: Check Code Quality
-on: [push, pull_request]
+on: [push, pull_request_target]
 env:
   PUBLIC_APIURL: ${{ vars.PUBLIC_APIURL }}
 jobs:

--- a/.github/workflows/codequality.yml
+++ b/.github/workflows/codequality.yml
@@ -10,8 +10,6 @@ jobs:
         working-directory: ./website-frontend
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,5 +1,5 @@
 name: Playwright Tests
-on: [push, pull_request]
+on: [push, pull_request_target]
 jobs:
   test:
     timeout-minutes: 60

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -9,8 +9,6 @@ jobs:
         working-directory: ./website-frontend
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -32,5 +32,5 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           name: playwright-report
-          path: playwright-report/
+          path: website-frontend/playwright-report/
           retention-days: 30

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,7 +1,5 @@
 name: Playwright Tests
 on: [push, pull_request]
-env:
-  PUBLIC_APIURL: ${{ vars.PUBLIC_APIURL }}
 jobs:
   test:
     timeout-minutes: 60
@@ -30,6 +28,8 @@ jobs:
         run: pnpm exec playwright install --with-deps
       - name: Run Playwright tests
         run: pnpm run test
+        env:
+          PUBLIC_APIURL: ${{ vars.PUBLIC_APIURL }}
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:


### PR DESCRIPTION
This PR elevates repository access privileges for test workflows, namely, `playwright.yml` and `codequality.yml`, to access repository variables such as `PUBLIC_APIURL`.

This PR also sanitizes some configurations like removing the `fetch-depth` outside `commitlint` and changing the scope of `PUBLIC_APIURL` to the desired step level. In addition, this PR fixed a bug regarding the playwright artifact step not showing up due to the misconfiguration of `path`.