### PR TITLE
feat(frontend): add `Alumni` model for valibot

### DIFF
--- a/website-frontend/src/lib/models/alumni.ts
+++ b/website-frontend/src/lib/models/alumni.ts
@@ -1,0 +1,8 @@
+import { cleanHtml } from '$lib/models-helpers';
+import { object, pipe, string, type InferOutput } from 'valibot';
+
+export const Alumni = object({
+	flexible_content: pipe(string(), cleanHtml)
+});
+
+export type Alumni = InferOutput<typeof Alumni>;

--- a/website-frontend/src/lib/models/schema.ts
+++ b/website-frontend/src/lib/models/schema.ts
@@ -2,11 +2,13 @@ import { object, type InferOutput } from 'valibot';
 import { Events } from './event';
 import { Global } from './global';
 import { StudentCouncil } from './student_council';
+import { Alumni } from './alumni';
 
 export const Schema = object({
 	global: Global,
 	events: Events,
-	student_council: StudentCouncil
+	student_council: StudentCouncil,
+	alumni: Alumni
 });
 
 export type Schema = InferOutput<typeof Schema>;

--- a/website-frontend/src/routes/+page.ts
+++ b/website-frontend/src/routes/+page.ts
@@ -2,7 +2,8 @@
 import getDirectusInstance from '$lib/directus';
 import { Global } from '$lib/models/global';
 import { Events } from '$lib/models/event';
-import { StudentCouncil } from '$lib/models/student_council.js';
+import { Alumni } from '$lib/models/alumni';
+import { StudentCouncil } from '$lib/models/student_council';
 import { readItems, readSingleton } from '@directus/sdk';
 import { parse } from 'valibot';
 export async function load({ fetch }) {
@@ -10,6 +11,10 @@ export async function load({ fetch }) {
 	return {
 		global: parse(Global, await directus.request(readSingleton('global'))),
 		events: parse(Events, await directus.request(readItems('events'))),
-		student_council: parse(StudentCouncil, await directus.request(readSingleton('student_council')))
+		student_council: parse(
+			StudentCouncil,
+			await directus.request(readSingleton('student_council'))
+		),
+		alumni: parse(Alumni, await directus.request(readSingleton('alumni')))
 	};
 }

--- a/website-frontend/tests/collections.spec.ts
+++ b/website-frontend/tests/collections.spec.ts
@@ -53,4 +53,10 @@ test.describe('Directus Collections', () => {
 		const test_request = await request.get(`${process.env.PUBLIC_APIURL}/items/laboratories`);
 		expect(test_request.ok()).toBeTruthy();
 	});
+
+	test('Alumni', async ({ request }) => {
+		const test_request = await request.get(`${process.env.PUBLIC_APIURL}/items/alumni`);
+		expect(test_request.ok()).toBeTruthy();
+		expect(parse(StudentCouncil, (await test_request.json()).data)).toBeTruthy();
+	});
 });


### PR DESCRIPTION
This PR adds the `Alumni` model for valibot validation in the frontend, with respect to the resolved Alumni collection in the CMS.