### PR TITLE
feat(frontend): add `linkages` model

### DIFF
--- a/website-frontend/src/lib/models/linkages.ts
+++ b/website-frontend/src/lib/models/linkages.ts
@@ -1,0 +1,8 @@
+import { cleanHtml } from '$lib/models-helpers';
+import { object, pipe, string, type InferOutput } from 'valibot';
+
+export const Linkages = object({
+	flexible_content: pipe(string(), cleanHtml)
+});
+
+export type Linkages = InferOutput<typeof Linkages>;

--- a/website-frontend/src/lib/models/schema.ts
+++ b/website-frontend/src/lib/models/schema.ts
@@ -3,12 +3,14 @@ import { Events } from './event';
 import { Global } from './global';
 import { StudentCouncil } from './student_council';
 import { Alumni } from './alumni';
+import { Linkages } from './linkages';
 
 export const Schema = object({
 	global: Global,
 	events: Events,
 	student_council: StudentCouncil,
-	alumni: Alumni
+	alumni: Alumni,
+	linkages: Linkages
 });
 
 export type Schema = InferOutput<typeof Schema>;

--- a/website-frontend/src/routes/+layout.server.ts
+++ b/website-frontend/src/routes/+layout.server.ts
@@ -5,6 +5,7 @@ import { Global } from '$lib/models/global';
 import { Events } from '$lib/models/event';
 import { Alumni } from '$lib/models/alumni';
 import { StudentCouncil } from '$lib/models/student_council';
+import { Linkages } from '$lib/models/linkages';
 import { readItems, readSingleton } from '@directus/sdk';
 import { parse } from 'valibot';
 import { createWriteStream } from 'fs';
@@ -51,7 +52,8 @@ export async function load({ fetch }) {
 			StudentCouncil,
 			await directus.request(readSingleton('student_council'))
 		),
-		alumni: parse(Alumni, await directus.request(readSingleton('alumni')))
+		alumni: parse(Alumni, await directus.request(readSingleton('alumni'))),
+		linkages: parse(Linkages, await directus.request(readSingleton('linkages')))
 	};
 
 	const asset_urls = {

--- a/website-frontend/src/routes/+layout.ts
+++ b/website-frontend/src/routes/+layout.ts
@@ -5,6 +5,7 @@ export async function load({ data }) {
 		events: data.schema.events,
 		student_council: data.schema.student_council,
 		alumni: data.schema.alumni,
+		linkages: data.schema.linkages,
 		assets: data.assets
 	};
 }


### PR DESCRIPTION
This pull request introduces a new `Linkages` model to the website front-end. The changes include defining the `Linkages` model, integrating it into the schema, and updating the layout to load `linkages` data.

This refers to [#72 in Taiga](https://tree.taiga.io/project/veeisforvanana-dcs-website-revamp/us/72?kanban-include_attachments=1&kanban-include_tasks=1&kanban-status=9725320). The path to the partnership page was not created because I believe it might be intended for the navigation bar ticket instead.