### PR TITLE
feat(Events): show events

### DIFF
--- a/website-frontend/src/lib/components/events/FeaturedEventCard.svelte
+++ b/website-frontend/src/lib/components/events/FeaturedEventCard.svelte
@@ -3,8 +3,8 @@
     export let event: Event;
 </script>
 
-<div class="card p-4 w-96 h-48">
-    <div class="flex justify-between mb-4">
+<div class="card p-4 w-72 max-w-72 md:w-96 md:max-w-96 h-fit snap-center">
+    <div class="md:flex md:justify-between mb-4">
         <h3>{event.event_headline}</h3>
         <h3>{new Date(event.date_created).toLocaleDateString()}</h3>
     </div>

--- a/website-frontend/src/lib/components/events/FeaturedEventCard.svelte
+++ b/website-frontend/src/lib/components/events/FeaturedEventCard.svelte
@@ -1,15 +1,15 @@
 <script lang="ts">
-    import { Event } from "$lib/models/event";
-    export let event: Event;
+	import { Event } from '$lib/models/event';
+	export let event: Event;
 </script>
 
 <div class="card p-4 w-72 max-w-72 md:w-96 md:max-w-96 h-fit snap-center">
-    <div class="md:flex md:justify-between mb-4">
-        <h3>{event.event_headline}</h3>
-        <h3>{new Date(event.date_created).toLocaleDateString()}</h3>
-    </div>
-    <div class="max-h-6 *:truncate overflow-hidden">
-        {@html event.event_content}
-    </div>
-    <a>View details &#8594;</a>
+	<div class="md:flex md:justify-between mb-4">
+		<h3>{event.event_headline}</h3>
+		<h3>{new Date(event.date_created).toLocaleDateString()}</h3>
+	</div>
+	<div class="max-h-6 *:truncate overflow-hidden">
+		{@html event.event_content}
+	</div>
+	<p>View details &#8594;</p>
 </div>

--- a/website-frontend/src/lib/components/events/FeaturedEventCard.svelte
+++ b/website-frontend/src/lib/components/events/FeaturedEventCard.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+    import { Event } from "$lib/models/event";
+    export let event: Event;
+</script>
+
+<div class="card p-4 w-96 h-48">
+    <div class="flex justify-between mb-4">
+        <h3>{event.event_headline}</h3>
+        <h3>{new Date(event.date_created).toLocaleDateString()}</h3>
+    </div>
+    {@html event.event_content}
+</div>

--- a/website-frontend/src/lib/components/events/FeaturedEventCard.svelte
+++ b/website-frontend/src/lib/components/events/FeaturedEventCard.svelte
@@ -3,12 +3,12 @@
 	export let event: Event;
 </script>
 
-<div class="card p-4 w-72 max-w-72 md:w-96 md:max-w-96 h-fit snap-center">
-	<div class="md:flex md:justify-between mb-4">
+<div class="card h-fit w-72 max-w-72 snap-center p-4 md:w-96 md:max-w-96">
+	<div class="mb-4 md:flex md:justify-between">
 		<h3>{event.event_headline}</h3>
 		<h3>{new Date(event.date_created).toLocaleDateString()}</h3>
 	</div>
-	<div class="max-h-6 *:truncate overflow-hidden">
+	<div class="max-h-6 overflow-hidden *:truncate">
 		{@html event.event_content}
 	</div>
 	<p>View details &#8594;</p>

--- a/website-frontend/src/lib/components/events/FeaturedEventCard.svelte
+++ b/website-frontend/src/lib/components/events/FeaturedEventCard.svelte
@@ -8,5 +8,8 @@
         <h3>{event.event_headline}</h3>
         <h3>{new Date(event.date_created).toLocaleDateString()}</h3>
     </div>
-    {@html event.event_content}
+    <div class="max-h-6 *:truncate overflow-hidden">
+        {@html event.event_content}
+    </div>
+    <a>View details &#8594;</a>
 </div>

--- a/website-frontend/src/routes/+page.svelte
+++ b/website-frontend/src/routes/+page.svelte
@@ -1,19 +1,19 @@
 <script lang="ts">
-    import { Event, Events } from "$lib/models/event";
-	import FeaturedEventCard from "$lib/components/events/FeaturedEventCard.svelte";
+	import { Event, Events } from '$lib/models/event';
+	import FeaturedEventCard from '$lib/components/events/FeaturedEventCard.svelte';
 
 	/** @type {import('./$types').PageData} */
 	export let data;
 
 	$: ({ global, events } = data);
 	events?.sort((e0: Event, e1: Event) => {
-        let d0 = new Date(e0.date_created),
-            d1 = new Date(e1.date_created);
-        return d1.getTime() - d0.getTime();
-    });
+		let d0 = new Date(e0.date_created),
+			d1 = new Date(e1.date_created);
+		return d1.getTime() - d0.getTime();
+	});
 
 	let featured: Events = [];
-    $: featured = events?.slice(0, 3);
+	$: featured = events?.slice(0, 3);
 </script>
 
 <div class="container mx-auto my-8 h-full flex-col items-center justify-center">

--- a/website-frontend/src/routes/+page.svelte
+++ b/website-frontend/src/routes/+page.svelte
@@ -1,10 +1,14 @@
 <script lang="ts">
+    import { Events } from "$lib/models/event";
 	import FeaturedEventCard from "$lib/components/events/FeaturedEventCard.svelte";
-	/** @type {import('./$types').PageData} */
 
+	/** @type {import('./$types').PageData} */
 	export let data;
 
 	$: ({ global, events } = data);
+
+	let featured: Events = [];
+    $: featured = events?.slice(0, 3);
 </script>
 
 <div class="container mx-auto my-8 h-full flex-col items-center justify-center">
@@ -18,7 +22,7 @@
 			<a href="/events">View all &#8594;</a>
 		</div>
 		<div class="flex my-12 space-x-8">
-			{#each events as event}
+			{#each featured as event}
 				<FeaturedEventCard {event} />
 			{/each}
 		</div>

--- a/website-frontend/src/routes/+page.svelte
+++ b/website-frontend/src/routes/+page.svelte
@@ -6,14 +6,16 @@
 	export let data;
 
 	$: ({ global, events } = data);
-	events?.sort((e0: Event, e1: Event) => {
+	
+	let sorted_events: Events = events;
+	$: sorted_events = events?.toSorted((e0: Event, e1: Event) => {
 		let d0 = new Date(e0.date_created),
 			d1 = new Date(e1.date_created);
 		return d1.getTime() - d0.getTime();
 	});
 
 	let featured: Events = [];
-	$: featured = events?.slice(0, 3);
+	$: featured = sorted_events?.slice(0, 3);
 </script>
 
 <div class="container mx-auto my-8 h-full flex-col items-center justify-center">

--- a/website-frontend/src/routes/+page.svelte
+++ b/website-frontend/src/routes/+page.svelte
@@ -11,15 +11,21 @@
 		<h1 class="h1">{global.title}</h1>
 		<p>{global.description}</p>
 	</div>
-	<div class="my-12 flex space-x-8">
-		{#each events as event}
-			<div class="card h-48 w-96 p-4">
-				<div class="mb-4 flex justify-between">
-					<h3>{event.event_headline}</h3>
-					<h3>{new Date(event.date_created).toLocaleDateString()}</h3>
+	<div>
+		<div class="flex justify-between">
+			<h2>Events</h2>
+			<a href="/events">View all &#8594;</a>
+		</div>
+		<div class="flex my-12 space-x-8">
+			{#each events as event}
+				<div class="card p-4 w-96 h-48">
+					<div class="flex justify-between mb-4">
+						<h3>{event.event_headline}</h3>
+						<h3>{new Date(event.date_created).toLocaleDateString()}</h3>
+					</div>
+					{@html event.event_content}
 				</div>
-				{@html event.event_content}
-			</div>
-		{/each}
+			{/each}
+		</div>
 	</div>
 </div>

--- a/website-frontend/src/routes/+page.svelte
+++ b/website-frontend/src/routes/+page.svelte
@@ -1,11 +1,16 @@
 <script lang="ts">
-    import { Events } from "$lib/models/event";
+    import { Event, Events } from "$lib/models/event";
 	import FeaturedEventCard from "$lib/components/events/FeaturedEventCard.svelte";
 
 	/** @type {import('./$types').PageData} */
 	export let data;
 
 	$: ({ global, events } = data);
+	events?.sort((e0: Event, e1: Event) => {
+        let d0 = new Date(e0.date_created),
+            d1 = new Date(e1.date_created);
+        return d1.getTime() - d0.getTime();
+    });
 
 	let featured: Events = [];
     $: featured = events?.slice(0, 3);

--- a/website-frontend/src/routes/+page.svelte
+++ b/website-frontend/src/routes/+page.svelte
@@ -16,12 +16,12 @@
 		<h1 class="h1">{global.title}</h1>
 		<p>{global.description}</p>
 	</div>
-	<div>
+	<div class="my-5">
 		<div class="flex justify-between">
 			<h2>Events</h2>
 			<a href="/events">View all &#8594;</a>
 		</div>
-		<div class="flex my-12 space-x-8">
+		<div class="flex my-12 space-x-8 overflow-x-auto">
 			{#each featured as event}
 				<FeaturedEventCard {event} />
 			{/each}

--- a/website-frontend/src/routes/+page.svelte
+++ b/website-frontend/src/routes/+page.svelte
@@ -6,7 +6,7 @@
 	export let data;
 
 	$: ({ global, events } = data);
-	
+
 	let sorted_events: Events = events;
 	$: sorted_events = events?.toSorted((e0: Event, e1: Event) => {
 		let d0 = new Date(e0.date_created),
@@ -28,7 +28,7 @@
 			<h2>Events</h2>
 			<a href="/events">View all &#8594;</a>
 		</div>
-		<div class="flex my-12 space-x-8 overflow-x-auto">
+		<div class="my-12 flex space-x-8 overflow-x-auto">
 			{#each featured as event}
 				<FeaturedEventCard {event} />
 			{/each}

--- a/website-frontend/src/routes/+page.svelte
+++ b/website-frontend/src/routes/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import FeaturedEventCard from "$lib/components/events/FeaturedEventCard.svelte";
 	/** @type {import('./$types').PageData} */
 
 	export let data;
@@ -18,13 +19,7 @@
 		</div>
 		<div class="flex my-12 space-x-8">
 			{#each events as event}
-				<div class="card p-4 w-96 h-48">
-					<div class="flex justify-between mb-4">
-						<h3>{event.event_headline}</h3>
-						<h3>{new Date(event.date_created).toLocaleDateString()}</h3>
-					</div>
-					{@html event.event_content}
-				</div>
+				<FeaturedEventCard {event} />
 			{/each}
 		</div>
 	</div>

--- a/website-frontend/src/routes/events/+page.svelte
+++ b/website-frontend/src/routes/events/+page.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	/** @type {import('./$types').PageData} */
+
+	export let data;
+
+	$: ({ events } = data);
+</script>
+
+<div class="container h-full mx-auto flex-col justify-center items-center my-8">
+	<div class="flex my-12 space-x-8">
+        {#each events as event}
+            <div class="card p-4 w-96 h-48">
+                <div class="flex justify-between mb-4">
+                    <h3>{event.event_headline}</h3>
+                    <h3>{new Date(event.date_created).toLocaleDateString()}</h3>
+                </div>
+                {@html event.event_content}
+            </div>
+        {/each}
+    </div>
+</div>

--- a/website-frontend/src/routes/events/+page.svelte
+++ b/website-frontend/src/routes/events/+page.svelte
@@ -6,7 +6,7 @@
 	export let data;
 
 	$: ({ events } = data);
-	
+
 	let sorted_events: Events = events;
 	$: sorted_events = events?.toSorted((e0: Event, e1: Event) => {
 		let d0 = new Date(e0.date_created),
@@ -18,19 +18,19 @@
 	$: featured = sorted_events?.slice(0, 3);
 </script>
 
-<div class="container h-full mx-auto flex-col justify-center items-center my-8">
-	<div class="flex my-12 space-x-8 overflow-x-auto">
+<div class="container mx-auto my-8 h-full flex-col items-center justify-center">
+	<div class="my-12 flex space-x-8 overflow-x-auto">
 		{#each featured as event}
 			<FeaturedEventCard {event} />
 		{/each}
 	</div>
 	<div>
 		{#each sorted_events as event}
-			<div class="md:grid md:grid-cols-6 border rounded p-4">
+			<div class="rounded border p-4 md:grid md:grid-cols-6">
 				<div class="md:col-span-5">
 					<h3>{event.event_headline}</h3>
 					<h3 class="block md:hidden">{new Date(event.date_created).toLocaleDateString()}</h3>
-					<div class="max-h-6 *:truncate overflow-hidden">
+					<div class="max-h-6 overflow-hidden *:truncate">
 						{@html event.event_content}
 					</div>
 					<p>View details &#8594;</p>
@@ -38,12 +38,12 @@
 						<p>Tags:</p>
 						{#if event.tags}
 							{#each event.tags as tag}
-								<p class="border rounded px-2 py-1 mx-2">{tag}</p>
+								<p class="mx-2 rounded border px-2 py-1">{tag}</p>
 							{/each}
 						{/if}
 					</div>
 				</div>
-				<div class="hidden md:block place-content-center">
+				<div class="hidden place-content-center md:block">
 					<h3>{new Date(event.date_created).toLocaleDateString()}</h3>
 				</div>
 			</div>

--- a/website-frontend/src/routes/events/+page.svelte
+++ b/website-frontend/src/routes/events/+page.svelte
@@ -17,4 +17,26 @@
             <FeaturedEventCard {event} />
         {/each}
     </div>
+    <div>
+        {#each events as event}
+            <div class="grid grid-cols-6 border rounded p-4">
+                <div class="col-span-5">
+                    <h3>{event.event_headline}</h3>
+                    <div class="max-h-6 *:truncate overflow-hidden">
+                        {@html event.event_content}
+                    </div>
+                    <a>View details &#8594;</a>
+                    <div class="flex items-center">
+                        <p>Tags: </p>
+                        {#each event.tags as tag}
+                            <p class="border rounded px-2 py-1 mx-2">{tag}</p>
+                        {/each}
+                    </div>
+                </div>
+                <div class="place-content-center">
+                    <h3>{new Date(event.date_created).toLocaleDateString()}</h3>
+                </div>
+            </div>
+        {/each}
+    </div>
 </div>

--- a/website-frontend/src/routes/events/+page.svelte
+++ b/website-frontend/src/routes/events/+page.svelte
@@ -36,9 +36,11 @@
 					<p>View details &#8594;</p>
 					<div class="flex items-center">
 						<p>Tags:</p>
-						{#each event.tags as tag}
-							<p class="border rounded px-2 py-1 mx-2">{tag}</p>
-						{/each}
+						{#if event.tags}
+							{#each event.tags as tag}
+								<p class="border rounded px-2 py-1 mx-2">{tag}</p>
+							{/each}
+						{/if}
 					</div>
 				</div>
 				<div class="hidden md:block place-content-center">

--- a/website-frontend/src/routes/events/+page.svelte
+++ b/website-frontend/src/routes/events/+page.svelte
@@ -1,11 +1,16 @@
 <script lang="ts">
-    import { Events } from "$lib/models/event";
+    import { Event, Events } from "$lib/models/event";
     import FeaturedEventCard from "$lib/components/events/FeaturedEventCard.svelte";
 
 	/** @type {import('./$types').PageData} */
 	export let data;
 
 	$: ({ events } = data);
+    events?.sort((e0: Event, e1: Event) => {
+        let d0 = new Date(e0.date_created),
+            d1 = new Date(e1.date_created);
+        return d1.getTime() - d0.getTime();
+    });
 
     let featured: Events = [];
     $: featured = events?.slice(0, 3);

--- a/website-frontend/src/routes/events/+page.svelte
+++ b/website-frontend/src/routes/events/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import FeaturedEventCard from "$lib/components/events/FeaturedEventCard.svelte";
 	/** @type {import('./$types').PageData} */
 
 	export let data;
@@ -9,13 +10,7 @@
 <div class="container h-full mx-auto flex-col justify-center items-center my-8">
 	<div class="flex my-12 space-x-8">
         {#each events as event}
-            <div class="card p-4 w-96 h-48">
-                <div class="flex justify-between mb-4">
-                    <h3>{event.event_headline}</h3>
-                    <h3>{new Date(event.date_created).toLocaleDateString()}</h3>
-                </div>
-                {@html event.event_content}
-            </div>
+            <FeaturedEventCard {event} />
         {/each}
     </div>
 </div>

--- a/website-frontend/src/routes/events/+page.svelte
+++ b/website-frontend/src/routes/events/+page.svelte
@@ -1,48 +1,48 @@
 <script lang="ts">
-    import { Event, Events } from "$lib/models/event";
-    import FeaturedEventCard from "$lib/components/events/FeaturedEventCard.svelte";
+	import { Event, Events } from '$lib/models/event';
+	import FeaturedEventCard from '$lib/components/events/FeaturedEventCard.svelte';
 
 	/** @type {import('./$types').PageData} */
 	export let data;
 
 	$: ({ events } = data);
-    events?.sort((e0: Event, e1: Event) => {
-        let d0 = new Date(e0.date_created),
-            d1 = new Date(e1.date_created);
-        return d1.getTime() - d0.getTime();
-    });
+	events?.sort((e0: Event, e1: Event) => {
+		let d0 = new Date(e0.date_created),
+			d1 = new Date(e1.date_created);
+		return d1.getTime() - d0.getTime();
+	});
 
-    let featured: Events = [];
-    $: featured = events?.slice(0, 3);
+	let featured: Events = [];
+	$: featured = events?.slice(0, 3);
 </script>
 
 <div class="container h-full mx-auto flex-col justify-center items-center my-8">
 	<div class="flex my-12 space-x-8 overflow-x-auto">
-        {#each featured as event}
-            <FeaturedEventCard {event} />
-        {/each}
-    </div>
-    <div>
-        {#each events as event}
-            <div class="md:grid md:grid-cols-6 border rounded p-4">
-                <div class="md:col-span-5">
-                    <h3>{event.event_headline}</h3>
-                    <h3 class="block md:hidden">{new Date(event.date_created).toLocaleDateString()}</h3>
-                    <div class="max-h-6 *:truncate overflow-hidden">
-                        {@html event.event_content}
-                    </div>
-                    <a>View details &#8594;</a>
-                    <div class="flex items-center">
-                        <p>Tags: </p>
-                        {#each event.tags as tag}
-                            <p class="border rounded px-2 py-1 mx-2">{tag}</p>
-                        {/each}
-                    </div>
-                </div>
-                <div class="hidden md:block place-content-center">
-                    <h3>{new Date(event.date_created).toLocaleDateString()}</h3>
-                </div>
-            </div>
-        {/each}
-    </div>
+		{#each featured as event}
+			<FeaturedEventCard {event} />
+		{/each}
+	</div>
+	<div>
+		{#each events as event}
+			<div class="md:grid md:grid-cols-6 border rounded p-4">
+				<div class="md:col-span-5">
+					<h3>{event.event_headline}</h3>
+					<h3 class="block md:hidden">{new Date(event.date_created).toLocaleDateString()}</h3>
+					<div class="max-h-6 *:truncate overflow-hidden">
+						{@html event.event_content}
+					</div>
+					<p>View details &#8594;</p>
+					<div class="flex items-center">
+						<p>Tags:</p>
+						{#each event.tags as tag}
+							<p class="border rounded px-2 py-1 mx-2">{tag}</p>
+						{/each}
+					</div>
+				</div>
+				<div class="hidden md:block place-content-center">
+					<h3>{new Date(event.date_created).toLocaleDateString()}</h3>
+				</div>
+			</div>
+		{/each}
+	</div>
 </div>

--- a/website-frontend/src/routes/events/+page.svelte
+++ b/website-frontend/src/routes/events/+page.svelte
@@ -6,14 +6,16 @@
 	export let data;
 
 	$: ({ events } = data);
-	events?.sort((e0: Event, e1: Event) => {
+	
+	let sorted_events: Events = events;
+	$: sorted_events = events?.toSorted((e0: Event, e1: Event) => {
 		let d0 = new Date(e0.date_created),
 			d1 = new Date(e1.date_created);
 		return d1.getTime() - d0.getTime();
 	});
 
 	let featured: Events = [];
-	$: featured = events?.slice(0, 3);
+	$: featured = sorted_events?.slice(0, 3);
 </script>
 
 <div class="container h-full mx-auto flex-col justify-center items-center my-8">
@@ -23,7 +25,7 @@
 		{/each}
 	</div>
 	<div>
-		{#each events as event}
+		{#each sorted_events as event}
 			<div class="md:grid md:grid-cols-6 border rounded p-4">
 				<div class="md:col-span-5">
 					<h3>{event.event_headline}</h3>

--- a/website-frontend/src/routes/events/+page.svelte
+++ b/website-frontend/src/routes/events/+page.svelte
@@ -12,16 +12,17 @@
 </script>
 
 <div class="container h-full mx-auto flex-col justify-center items-center my-8">
-	<div class="flex my-12 space-x-8">
+	<div class="flex my-12 space-x-8 overflow-x-auto">
         {#each featured as event}
             <FeaturedEventCard {event} />
         {/each}
     </div>
     <div>
         {#each events as event}
-            <div class="grid grid-cols-6 border rounded p-4">
-                <div class="col-span-5">
+            <div class="md:grid md:grid-cols-6 border rounded p-4">
+                <div class="md:col-span-5">
                     <h3>{event.event_headline}</h3>
+                    <h3 class="block md:hidden">{new Date(event.date_created).toLocaleDateString()}</h3>
                     <div class="max-h-6 *:truncate overflow-hidden">
                         {@html event.event_content}
                     </div>
@@ -33,7 +34,7 @@
                         {/each}
                     </div>
                 </div>
-                <div class="place-content-center">
+                <div class="hidden md:block place-content-center">
                     <h3>{new Date(event.date_created).toLocaleDateString()}</h3>
                 </div>
             </div>

--- a/website-frontend/src/routes/events/+page.svelte
+++ b/website-frontend/src/routes/events/+page.svelte
@@ -1,15 +1,19 @@
 <script lang="ts">
+    import { Events } from "$lib/models/event";
     import FeaturedEventCard from "$lib/components/events/FeaturedEventCard.svelte";
-	/** @type {import('./$types').PageData} */
 
+	/** @type {import('./$types').PageData} */
 	export let data;
 
 	$: ({ events } = data);
+
+    let featured: Events = [];
+    $: featured = events?.slice(0, 3);
 </script>
 
 <div class="container h-full mx-auto flex-col justify-center items-center my-8">
 	<div class="flex my-12 space-x-8">
-        {#each events as event}
+        {#each featured as event}
             <FeaturedEventCard {event} />
         {/each}
     </div>


### PR DESCRIPTION
This PR...

- links the home page to the events page via the "View all" link above the featured events
- features events in both the home and the events pages based on recency
- shows all events in the events page
- adds responsive CSS to the layouts of the events page and the featured events in the home page