### PR TITLE
build(deps): add prettier-plugin-tailwindcss

### DIFF
--- a/website-frontend/.prettierrc
+++ b/website-frontend/.prettierrc
@@ -3,6 +3,6 @@
 	"singleQuote": true,
 	"trailingComma": "none",
 	"printWidth": 100,
-	"plugins": ["prettier-plugin-svelte"],
+	"plugins": ["prettier-plugin-svelte", "prettier-plugin-tailwindcss"],
 	"overrides": [{ "files": "*.svelte", "options": { "parser": "svelte" } }]
 }

--- a/website-frontend/package.json
+++ b/website-frontend/package.json
@@ -34,6 +34,7 @@
 		"postcss": "8.4.47",
 		"prettier": "^3.4.2",
 		"prettier-plugin-svelte": "^3.3.2",
+		"prettier-plugin-tailwindcss": "^0.6.9",
 		"svelte": "^4.2.19",
 		"svelte-check": "^4.1.1",
 		"tailwind-merge": "^2.5.5",

--- a/website-frontend/pnpm-lock.yaml
+++ b/website-frontend/pnpm-lock.yaml
@@ -76,6 +76,9 @@ devDependencies:
   prettier-plugin-svelte:
     specifier: ^3.3.2
     version: 3.3.2(prettier@3.4.2)(svelte@4.2.19)
+  prettier-plugin-tailwindcss:
+    specifier: ^0.6.9
+    version: 0.6.9(prettier-plugin-svelte@3.3.2)(prettier@3.4.2)
   svelte:
     specifier: ^4.2.19
     version: 4.2.19
@@ -2132,6 +2135,65 @@ packages:
     dependencies:
       prettier: 3.4.2
       svelte: 4.2.19
+    dev: true
+
+  /prettier-plugin-tailwindcss@0.6.9(prettier-plugin-svelte@3.3.2)(prettier@3.4.2):
+    resolution: {integrity: sha512-r0i3uhaZAXYP0At5xGfJH876W3HHGHDp+LCRUJrs57PBeQ6mYHMwr25KH8NPX44F2yGTvdnH7OqCshlQx183Eg==}
+    engines: {node: '>=14.21.3'}
+    peerDependencies:
+      '@ianvs/prettier-plugin-sort-imports': '*'
+      '@prettier/plugin-pug': '*'
+      '@shopify/prettier-plugin-liquid': '*'
+      '@trivago/prettier-plugin-sort-imports': '*'
+      '@zackad/prettier-plugin-twig-melody': '*'
+      prettier: ^3.0
+      prettier-plugin-astro: '*'
+      prettier-plugin-css-order: '*'
+      prettier-plugin-import-sort: '*'
+      prettier-plugin-jsdoc: '*'
+      prettier-plugin-marko: '*'
+      prettier-plugin-multiline-arrays: '*'
+      prettier-plugin-organize-attributes: '*'
+      prettier-plugin-organize-imports: '*'
+      prettier-plugin-sort-imports: '*'
+      prettier-plugin-style-order: '*'
+      prettier-plugin-svelte: '*'
+    peerDependenciesMeta:
+      '@ianvs/prettier-plugin-sort-imports':
+        optional: true
+      '@prettier/plugin-pug':
+        optional: true
+      '@shopify/prettier-plugin-liquid':
+        optional: true
+      '@trivago/prettier-plugin-sort-imports':
+        optional: true
+      '@zackad/prettier-plugin-twig-melody':
+        optional: true
+      prettier-plugin-astro:
+        optional: true
+      prettier-plugin-css-order:
+        optional: true
+      prettier-plugin-import-sort:
+        optional: true
+      prettier-plugin-jsdoc:
+        optional: true
+      prettier-plugin-marko:
+        optional: true
+      prettier-plugin-multiline-arrays:
+        optional: true
+      prettier-plugin-organize-attributes:
+        optional: true
+      prettier-plugin-organize-imports:
+        optional: true
+      prettier-plugin-sort-imports:
+        optional: true
+      prettier-plugin-style-order:
+        optional: true
+      prettier-plugin-svelte:
+        optional: true
+    dependencies:
+      prettier: 3.4.2
+      prettier-plugin-svelte: 3.3.2(prettier@3.4.2)(svelte@4.2.19)
     dev: true
 
   /prettier@3.4.2:

--- a/website-frontend/src/lib/components/nav/NavBar.svelte
+++ b/website-frontend/src/lib/components/nav/NavBar.svelte
@@ -4,20 +4,20 @@
 
 <div
 	class="
-    w-full md:h-full md:flex md:justify-center md:my-2
-	hidden
+    hidden w-full md:my-2 md:flex md:h-full
+	md:justify-center
 "
 >
 	<nav
 		class="
-        bg-background md:p-1 md:sticky flex md:justify-between md:border md:rounded-3xl md:h-fit md:w-fit
-        fixed justify-end h-screen w-full md:px-5
+        fixed flex h-screen w-full justify-end bg-background md:sticky md:h-fit md:w-fit
+        md:justify-between md:rounded-3xl md:border md:p-1 md:px-5
     "
 	>
 		<ul
 			class="
-            md:flex md:justify-center gap-2 md:static w-full
-            absolute right-0 bottom-10
+            absolute bottom-10 right-0 w-full gap-2
+            md:static md:flex md:justify-center
         "
 		>
 			<NavItem href="/" to="Home" />

--- a/website-frontend/src/lib/components/nav/NavItem.svelte
+++ b/website-frontend/src/lib/components/nav/NavItem.svelte
@@ -9,7 +9,7 @@
 </script>
 
 <li
-	class="w-full relative md:rounded-sm transition-colors duration-300 ease-in-out hover:bg-accent {custom}"
+	class="relative w-full transition-colors duration-300 ease-in-out hover:bg-accent md:rounded-sm {custom}"
 	on:mouseenter={() => {
 		show = true;
 	}}
@@ -19,8 +19,8 @@
 >
 	<div
 		class="
-        md:text-sm md:block
-        text-2xl flex justify-end
+        flex justify-end
+        text-2xl md:block md:text-sm
     "
 	>
 		{#if dropdown}
@@ -40,16 +40,16 @@
 		<a
 			{href}
 			class="
-            px-3 py-1 flex md:items-center md:justify-start md:text-left md:border-0
-            justify-end w-fit text-right border-r-2
+            flex w-fit justify-end border-r-2 px-3 py-1 text-right
+            md:items-center md:justify-start md:border-0 md:text-left
         ">{to}</a
 		>
 	</div>
 	{#if show && dropdown}
 		<ul
 			class="
-                md:absolute md:w-40 md:p-0.5 bg-background md:border md:rounded-lg
-                w-full pr-4
+                w-full bg-background pr-4 md:absolute md:w-40 md:rounded-lg
+                md:border md:p-0.5
                 {position}
             "
 			transition:slide

--- a/website-frontend/src/routes/+page.svelte
+++ b/website-frontend/src/routes/+page.svelte
@@ -6,15 +6,15 @@
 	$: ({ global, events } = data);
 </script>
 
-<div class="container h-full mx-auto flex-col justify-center items-center my-8">
+<div class="container mx-auto my-8 h-full flex-col items-center justify-center">
 	<div class="space-y-5">
 		<h1 class="h1">{global.title}</h1>
 		<p>{global.description}</p>
 	</div>
-	<div class="flex my-12 space-x-8">
+	<div class="my-12 flex space-x-8">
 		{#each events as event}
-			<div class="card p-4 w-96 h-48">
-				<div class="flex justify-between mb-4">
+			<div class="card h-48 w-96 p-4">
+				<div class="mb-4 flex justify-between">
 					<h3>{event.event_headline}</h3>
 					<h3>{new Date(event.date_created).toLocaleDateString()}</h3>
 				</div>

--- a/website-frontend/src/routes/academics/[slug]/+page.svelte
+++ b/website-frontend/src/routes/academics/[slug]/+page.svelte
@@ -6,26 +6,26 @@
 	{#if data.program}
 		<div class="relative">
 			<div
-				class="bg-cover bg-center h-[40vh] md:h-[50vh]"
+				class="h-[40vh] bg-cover bg-center md:h-[50vh]"
 				style="background-image: linear-gradient(to top, #004420, transparent), url('{data.program
 					.image}')"
 			></div>
 
 			<div class="absolute bottom-9">
-				<h1 class="font-bold text-3xl px-4 md:px-32 md:text-5xl md:max-w-[60vw]">
+				<h1 class="px-4 text-3xl font-bold md:max-w-[60vw] md:px-32 md:text-5xl">
 					{data.program.title}
 				</h1>
 			</div>
 		</div>
 
-		<div class="text-[#01152B] text-base px-4 py-10 md:px-32">
+		<div class="px-4 py-10 text-base text-[#01152B] md:px-32">
 			{@html data.program.description}
 
-			<div class="max-w-6xl rounded-md overflow-hidden shadow-lg bg-white my-10">
-				<div class="px-4 md:px-6 py-8">
-					<div class="font-bold text-xl mb-8">Curriculum</div>
+			<div class="my-10 max-w-6xl overflow-hidden rounded-md bg-white shadow-lg">
+				<div class="px-4 py-8 md:px-6">
+					<div class="mb-8 text-xl font-bold">Curriculum</div>
 
-					<p class="text-gray-500 text-sm">Core Courses</p>
+					<p class="text-sm text-gray-500">Core Courses</p>
 					<p class="text-base">
 						{@html data.program.curriculum}
 					</p>


### PR DESCRIPTION
This PR adds the `prettier-plugin-tailwindcss` plugin for prettier. This ensures more consistency upon reading and writing tailwind CSS code for website components.