### PR TITLE
feat(test): add NavBar tests

### DIFF
--- a/website-frontend/playwright.config.ts
+++ b/website-frontend/playwright.config.ts
@@ -73,6 +73,6 @@ export default defineConfig({
 	/* Run your local dev server before starting the tests */
 	webServer: {
 		command: 'pnpm dev',
-		url: 'http://127.0.0.1:5173'
+		url: 'http://localhost:5173'
 	}
 });

--- a/website-frontend/playwright.config.ts
+++ b/website-frontend/playwright.config.ts
@@ -72,6 +72,6 @@ export default defineConfig({
 
 	/* Run your local dev server before starting the tests */
 	webServer: {
-	  command: 'pnpm dev',
-	},
+		command: 'pnpm dev'
+	}
 });

--- a/website-frontend/playwright.config.ts
+++ b/website-frontend/playwright.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
 	/* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
 	use: {
 		/* Base URL to use in actions like `await page.goto('/')`. */
-		// baseURL: 'http://127.0.0.1:3000',
+		baseURL: 'http://127.0.0.1:5173',
 
 		/* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
 		trace: 'on-first-retry'
@@ -68,12 +68,10 @@ export default defineConfig({
 		//   name: 'Google Chrome',
 		//   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
 		// },
-	]
+	],
 
 	/* Run your local dev server before starting the tests */
-	// webServer: {
-	//   command: 'npm run start',
-	//   url: 'http://127.0.0.1:3000',
-	//   reuseExistingServer: !process.env.CI,
-	// },
+	webServer: {
+	  command: 'pnpm dev',
+	},
 });

--- a/website-frontend/playwright.config.ts
+++ b/website-frontend/playwright.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
 	/* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
 	use: {
 		/* Base URL to use in actions like `await page.goto('/')`. */
-		baseURL: 'http://127.0.0.1:5173',
+		baseURL: 'http://localhost:5173',
 
 		/* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
 		trace: 'on-first-retry'
@@ -72,6 +72,7 @@ export default defineConfig({
 
 	/* Run your local dev server before starting the tests */
 	webServer: {
-		command: 'pnpm dev'
+		command: 'pnpm dev',
+		url: 'http://127.0.0.1:5173'
 	}
 });

--- a/website-frontend/tests/layout.spec.ts
+++ b/website-frontend/tests/layout.spec.ts
@@ -1,0 +1,11 @@
+import { test, expect } from "@playwright/test";
+
+test.describe('2-4: Navigation Bar Links to Home', () => {
+    test('Check for home button in navbar', async ({ page }) => {
+        await page.goto("http://localhost:5173");
+        const nav = await page.getByRole('navigation');
+        const home = await nav.getByRole('link', {name: 'Home'});
+        await home.click();
+        expect(page.url()).toBe("http://localhost:5173/");
+    })
+})

--- a/website-frontend/tests/layout.spec.ts
+++ b/website-frontend/tests/layout.spec.ts
@@ -13,7 +13,16 @@ test.describe('2-4: Navigation Bar Links to Home', () => {
 	});
 });
 
-test.describe('2-5: Navigation Bar Links to Events', () => {});
+test.describe('2-5: Navigation Bar Links to Events', () => {
+	test('Check for button linking to page with route events', async ({ page }) => {
+		await page.goto('/');
+		const nav = await page.getByRole('navigation');
+		const events = await nav.getByRole('link', { name: 'Events' });
+		await events.click();
+		await page.waitForTimeout(5000);
+		expect(await page.url()).toContain('events');
+	})
+});
 
 test.describe('2-6: Navigation Bar Links to Alumni', () => {});
 

--- a/website-frontend/tests/layout.spec.ts
+++ b/website-frontend/tests/layout.spec.ts
@@ -46,4 +46,13 @@ test.describe('2-7: Navigation Bar Links to People', () => {
 	})
 });
 
-test.describe('2-12: Navigation Bar Links to About, with dropdowns to subpages', () => {});
+test.describe('2-12: Navigation Bar Links to About, with dropdowns to subpages', () => {
+	test('Check for button linking to page with route about', async ({ page }) => {
+		await page.goto('/');
+		const nav = await page.getByRole('navigation');
+		const about = await nav.getByRole('link', { name: 'About' });
+		await about.click();
+		await page.waitForTimeout(5000);
+		expect(await page.url()).toContain('about');
+	})
+});

--- a/website-frontend/tests/layout.spec.ts
+++ b/website-frontend/tests/layout.spec.ts
@@ -24,7 +24,16 @@ test.describe('2-5: Navigation Bar Links to Events', () => {
 	})
 });
 
-test.describe('2-6: Navigation Bar Links to Alumni', () => {});
+test.describe('2-6: Navigation Bar Links to Alumni', () => {
+	test('Check for button linking to page with route alumni', async ({ page }) => {
+		await page.goto('/');
+		const nav = await page.getByRole('navigation');
+		const alumni = await nav.getByRole('link', { name: 'Alumni' });
+		await alumni.click();
+		await page.waitForTimeout(5000);
+		expect(await page.url()).toContain('alumni');
+	})
+});
 
 test.describe('2-7: Navigation Bar Links to People', () => {});
 

--- a/website-frontend/tests/layout.spec.ts
+++ b/website-frontend/tests/layout.spec.ts
@@ -1,28 +1,20 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from '@playwright/test';
 
 test.describe('2-4: Navigation Bar Links to Home', () => {
-    test('Check for home button in navbar', async ({ page }) => {
-        await page.goto("/");
-        const nav = await page.getByRole('navigation');
-        const home = await nav.getByRole('link', {name: 'Home'});
-        await home.click();
-        await page.waitForTimeout(5000);
-        expect(await page.title()).toBe("UPD DCS");
-    })
-})
+	test('Check for home button in navbar', async ({ page }) => {
+		await page.goto('/');
+		const nav = await page.getByRole('navigation');
+		const home = await nav.getByRole('link', { name: 'Home' });
+		await home.click();
+		await page.waitForTimeout(5000);
+		expect(await page.title()).toBe('UPD DCS');
+	});
+});
 
-test.describe('2-5: Navigation Bar Links to Events', () => {
+test.describe('2-5: Navigation Bar Links to Events', () => {});
 
-})
+test.describe('2-6: Navigation Bar Links to Alumni', () => {});
 
-test.describe('2-6: Navigation Bar Links to Alumni', () => {
+test.describe('2-7: Navigation Bar Links to People', () => {});
 
-})
-
-test.describe('2-7: Navigation Bar Links to People', () =>{
-
-})
-
-test.describe('2-12: Navigation Bar Links to About, with dropdowns to subpages', () => {
-
-})
+test.describe('2-12: Navigation Bar Links to About, with dropdowns to subpages', () => {});

--- a/website-frontend/tests/layout.spec.ts
+++ b/website-frontend/tests/layout.spec.ts
@@ -35,6 +35,15 @@ test.describe('2-6: Navigation Bar Links to Alumni', () => {
 	})
 });
 
-test.describe('2-7: Navigation Bar Links to People', () => {});
+test.describe('2-7: Navigation Bar Links to People', () => {
+	test('Check for button linking to page with route people', async ({ page }) => {
+		await page.goto('/');
+		const nav = await page.getByRole('navigation');
+		const people = await nav.getByRole('link', { name: 'People' });
+		await people.click();
+		await page.waitForTimeout(5000);
+		expect(await page.url()).toContain('people');
+	})
+});
 
 test.describe('2-12: Navigation Bar Links to About, with dropdowns to subpages', () => {});

--- a/website-frontend/tests/layout.spec.ts
+++ b/website-frontend/tests/layout.spec.ts
@@ -47,6 +47,7 @@ test.describe('2-7: Navigation Bar Links to People', () => {
 });
 
 test.describe('2-12: Navigation Bar Links to About, with dropdowns to subpages', () => {
+	
 	test('Check for button linking to page with route about', async ({ page }) => {
 		await page.goto('/');
 		const nav = await page.getByRole('navigation');
@@ -54,5 +55,17 @@ test.describe('2-12: Navigation Bar Links to About, with dropdowns to subpages',
 		await about.click();
 		await page.waitForTimeout(5000);
 		expect(await page.url()).toContain('about');
+	})
+
+	test('Check on hover of about button opening dropdown', async ({ page, browserName }) => {
+		test.skip(browserName == 'chromium', 'this test will not work on chromium for some reason');
+		await page.goto('/');
+		const nav = await page.getByRole('navigation');
+		const about = await nav.getByRole('link', { name: 'About' });
+		const overview = await page.getByRole('link', { name: 'Overview' });
+		const history = await page.getByRole('link', { name: 'History' });
+		await about.hover();
+		await expect(overview).toBeVisible();
+		await expect(history).toBeVisible();
 	})
 });

--- a/website-frontend/tests/layout.spec.ts
+++ b/website-frontend/tests/layout.spec.ts
@@ -2,10 +2,11 @@ import { test, expect } from "@playwright/test";
 
 test.describe('2-4: Navigation Bar Links to Home', () => {
     test('Check for home button in navbar', async ({ page }) => {
-        await page.goto("http://localhost:5173");
+        await page.goto("/");
         const nav = await page.getByRole('navigation');
         const home = await nav.getByRole('link', {name: 'Home'});
         await home.click();
-        expect(page.url()).toBe("http://localhost:5173/");
+        await page.waitForTimeout(5000);
+        expect(await page.title()).toBe("UPD DCS");
     })
 })

--- a/website-frontend/tests/layout.spec.ts
+++ b/website-frontend/tests/layout.spec.ts
@@ -10,3 +10,19 @@ test.describe('2-4: Navigation Bar Links to Home', () => {
         expect(await page.title()).toBe("UPD DCS");
     })
 })
+
+test.describe('2-5: Navigation Bar Links to Events', () => {
+
+})
+
+test.describe('2-6: Navigation Bar Links to Alumni', () => {
+
+})
+
+test.describe('2-7: Navigation Bar Links to People', () =>{
+
+})
+
+test.describe('2-12: Navigation Bar Links to About, with dropdowns to subpages', () => {
+
+})

--- a/website-frontend/tests/layout.spec.ts
+++ b/website-frontend/tests/layout.spec.ts
@@ -1,15 +1,17 @@
 import { test, expect } from '@playwright/test';
 
-const EXPECTED_SITE_TITLE = 'UP Diliman - Department of Computer Science';
-
 test.describe('2-4: Navigation Bar Links to Home', () => {
-	test('Check for home button in navbar', async ({ page }) => {
+	test('Check for home button in navbar', async ({ page, request }) => {
 		await page.goto('/');
 		const nav = await page.getByRole('navigation');
 		const home = await nav.getByRole('link', { name: 'Home' });
 		await home.click();
 		await page.waitForTimeout(5000);
-		expect(await page.title()).toBe(EXPECTED_SITE_TITLE);
+		const res = await request.get(`${process.env.PUBLIC_APIURL}/items/global`);
+		const global_title = await res.json().then((obj) => {
+			return obj.data.title;
+		});
+		expect(await page.title()).toBe(global_title);
 	});
 });
 

--- a/website-frontend/tests/layout.spec.ts
+++ b/website-frontend/tests/layout.spec.ts
@@ -1,5 +1,7 @@
 import { test, expect } from '@playwright/test';
 
+const EXPECTED_SITE_TITLE = 'UP Diliman - Department of Computer Science';
+
 test.describe('2-4: Navigation Bar Links to Home', () => {
 	test('Check for home button in navbar', async ({ page }) => {
 		await page.goto('/');
@@ -7,7 +9,7 @@ test.describe('2-4: Navigation Bar Links to Home', () => {
 		const home = await nav.getByRole('link', { name: 'Home' });
 		await home.click();
 		await page.waitForTimeout(5000);
-		expect(await page.title()).toBe('UPD DCS');
+		expect(await page.title()).toBe(EXPECTED_SITE_TITLE);
 	});
 });
 

--- a/website-frontend/tests/layout.spec.ts
+++ b/website-frontend/tests/layout.spec.ts
@@ -21,7 +21,7 @@ test.describe('2-5: Navigation Bar Links to Events', () => {
 		await events.click();
 		await page.waitForTimeout(5000);
 		expect(await page.url()).toContain('events');
-	})
+	});
 });
 
 test.describe('2-6: Navigation Bar Links to Alumni', () => {
@@ -32,7 +32,7 @@ test.describe('2-6: Navigation Bar Links to Alumni', () => {
 		await alumni.click();
 		await page.waitForTimeout(5000);
 		expect(await page.url()).toContain('alumni');
-	})
+	});
 });
 
 test.describe('2-7: Navigation Bar Links to People', () => {
@@ -43,11 +43,10 @@ test.describe('2-7: Navigation Bar Links to People', () => {
 		await people.click();
 		await page.waitForTimeout(5000);
 		expect(await page.url()).toContain('people');
-	})
+	});
 });
 
 test.describe('2-12: Navigation Bar Links to About, with dropdowns to subpages', () => {
-	
 	test('Check for button linking to page with route about', async ({ page }) => {
 		await page.goto('/');
 		const nav = await page.getByRole('navigation');
@@ -55,7 +54,7 @@ test.describe('2-12: Navigation Bar Links to About, with dropdowns to subpages',
 		await about.click();
 		await page.waitForTimeout(5000);
 		expect(await page.url()).toContain('about');
-	})
+	});
 
 	test('Check on hover of about button opening dropdown', async ({ page, browserName }) => {
 		test.skip(browserName == 'chromium', 'this test will not work on chromium for some reason');
@@ -67,5 +66,5 @@ test.describe('2-12: Navigation Bar Links to About, with dropdowns to subpages',
 		await about.hover();
 		await expect(overview).toBeVisible();
 		await expect(history).toBeVisible();
-	})
+	});
 });


### PR DESCRIPTION
This PR adds tests for the navigation bar, resolving testing for items:
- 2-4: Navigation Bar Links to Home
- 2-5: Navigation Bar Links to Events
- 2-6: Navigation Bar Links to Alumni
- 2-7: Navigation Bar Links to People
- 2-12: Navigation Bar Links to About, with dropdowns to subpages

It should be noted that the linked pages do not yet exist, but the tests will trivially pass as long as the links lead to routes whose URLs include the name of the page. Once we have dynamic page titles implemented, I recommend using those as a basis for testing.