### PR TITLE
refactor: limit data returns for routes

### DIFF
--- a/website-frontend/src/lib/components/nav/Header.svelte
+++ b/website-frontend/src/lib/components/nav/Header.svelte
@@ -1,19 +1,19 @@
 <script lang="ts">
 	import FacebookIcon from '$lib/assets/FacebookIcon.svelte';
 	import XIcon from '$lib/assets/XIcon.svelte';
-	export let assets;
+	export let favicon;
 </script>
 
 <div class="h-14 items-center bg-slate-50 py-2 md:h-16">
 	<div class="flex justify-between px-2 md:px-9">
 		<div class="my-auto flex items-center">
 			<img
-				src={assets.favicon}
+				src={favicon}
 				alt="UP"
 				class="mr-1 hidden h-12 w-12 max-w-xs rounded-full bg-gray-400 md:block"
 			/>
 			<img
-				src={assets.favicon}
+				src={favicon}
 				alt="DCS"
 				class="mr-2 h-10 w-10 max-w-xs rounded-full bg-gray-400 md:mr-3 md:h-12 md:w-12"
 			/>

--- a/website-frontend/src/lib/server/assets.ts
+++ b/website-frontend/src/lib/server/assets.ts
@@ -1,0 +1,31 @@
+import downloadData from './download';
+
+async function obtainAssets(asset_urls: object) {
+	const assets = await Promise.allSettled(
+		Object.entries(asset_urls).map(([key, url]) =>
+			downloadData(url, key).then((path) => [key, path])
+		)
+	).then((results) =>
+		Object.fromEntries(
+			results.map((result, index) => {
+				const key = Object.keys(asset_urls)[index];
+				if (result.status === 'fulfilled') {
+					return result.value;
+				} else {
+					return [key, null];
+				}
+			})
+		)
+	);
+
+	// Ensure fallbacks for undefined assets
+	Object.keys(asset_urls).forEach((key) => {
+		if (!assets[key]) {
+			assets[key] = '/default/path/to/fallback.png'; // Replace with actual fallback
+		}
+	});
+
+	return assets;
+}
+
+export default obtainAssets;

--- a/website-frontend/src/lib/server/download.ts
+++ b/website-frontend/src/lib/server/download.ts
@@ -1,0 +1,35 @@
+import { createWriteStream } from 'fs';
+import { Readable } from 'stream';
+import { ReadableStream } from 'stream/web';
+import { finished } from 'stream/promises';
+
+async function downloadData(url: string, file_name: string) {
+	return fetch(url)
+		.then((res) => {
+			if (!res.ok) {
+				return Promise.reject(`Fetch failed with status: ${res.status}`);
+			}
+
+			const content_type = res.headers.get('content-type');
+			if (!content_type) {
+				return Promise.reject('Missing content-type header.');
+			}
+
+			const extension = content_type.split('/').pop();
+			if (!extension) {
+				return Promise.reject('Unable to determine file extension.');
+			}
+
+			const path = `./static/${file_name}.${extension}`;
+			const file_stream = createWriteStream(path);
+
+			return finished(
+				Readable.fromWeb(res.body as ReadableStream<Uint8Array>).pipe(file_stream)
+			).then(() => path); // Return the file path when complete
+		})
+		.catch(() => {
+			return null; // Return `null` if any error occurs
+		});
+}
+
+export default downloadData;

--- a/website-frontend/src/lib/server/schema.ts
+++ b/website-frontend/src/lib/server/schema.ts
@@ -1,0 +1,25 @@
+import { Global } from '$lib/models/global';
+import { Events } from '$lib/models/event';
+import { Alumni } from '$lib/models/alumni';
+import { StudentCouncil } from '$lib/models/student_council';
+import { Linkages } from '$lib/models/linkages';
+import { type Schema } from '$lib/models/schema';
+import { type RestClient, readItems, readSingleton } from '@directus/sdk';
+import { parse } from 'valibot';
+
+async function obtainSchema(directus: RestClient<Schema>, keys: Array<string>) {
+	const schema = {
+		global: parse(Global, await directus.request(readSingleton('global'))),
+		events: parse(Events, await directus.request(readItems('events'))),
+		student_council: parse(
+			StudentCouncil,
+			await directus.request(readSingleton('student_council'))
+		),
+		alumni: parse(Alumni, await directus.request(readSingleton('alumni'))),
+		linkages: parse(Linkages, await directus.request(readSingleton('linkages')))
+	};
+
+	return Object.fromEntries(Object.entries(schema).filter(([key]) => keys.includes(key))) as Schema;
+}
+
+export default obtainSchema;

--- a/website-frontend/src/routes/+layout.server.ts
+++ b/website-frontend/src/routes/+layout.server.ts
@@ -1,116 +1,19 @@
 /** @type {import('./$types').LayoutServerLoad} */
-import getDirectusInstance from '$lib/directus';
 import { PUBLIC_APIURL } from '$env/static/public';
-import { Global } from '$lib/models/global';
-import { Events } from '$lib/models/event';
-import { Alumni } from '$lib/models/alumni';
-import { StudentCouncil } from '$lib/models/student_council';
-import { Linkages } from '$lib/models/linkages';
-import { People } from '$lib/models/people';
-import { PeopleOverview } from '$lib/models/people_overview';
-import { PeopleCategories } from '$lib/models/people_categories';
-import { PeopleLaboratories } from '$lib/models/people_laboratories';
-import { Laboratories } from '$lib/models/laboratories';
-import { type Schema } from '$lib/models/schema';
-import { type RestClient, readItems, readSingleton } from '@directus/sdk';
-import { parse } from 'valibot';
-import { createWriteStream } from 'fs';
-import { Readable } from 'stream';
-import { ReadableStream } from 'stream/web';
-import { finished } from 'stream/promises';
-
-async function downloadData(url: string, file_name: string) {
-	return fetch(url)
-		.then((res) => {
-			if (!res.ok) {
-				return Promise.reject(`Fetch failed with status: ${res.status}`);
-			}
-
-			const content_type = res.headers.get('content-type');
-			if (!content_type) {
-				return Promise.reject('Missing content-type header.');
-			}
-
-			const extension = content_type.split('/').pop();
-			if (!extension) {
-				return Promise.reject('Unable to determine file extension.');
-			}
-
-			const path = `./static/${file_name}.${extension}`;
-			const file_stream = createWriteStream(path);
-
-			return finished(
-				Readable.fromWeb(res.body as ReadableStream<Uint8Array>).pipe(file_stream)
-			).then(() => path); // Return the file path when complete
-		})
-		.catch(() => {
-			return null; // Return `null` if any error occurs
-		});
-}
-
-async function obtainSchema(directus: RestClient<Schema>) {
-	const schema = {
-		global: parse(Global, await directus.request(readSingleton('global'))),
-		events: parse(Events, await directus.request(readItems('events'))),
-		student_council: parse(
-			StudentCouncil,
-			await directus.request(readSingleton('student_council'))
-		),
-		alumni: parse(Alumni, await directus.request(readSingleton('alumni'))),
-		linkages: parse(Linkages, await directus.request(readSingleton('linkages'))),
-		people: parse(People, await directus.request(readItems('people'))),
-		people_overview: parse(
-			PeopleOverview,
-			await directus.request(readSingleton('people_overview'))
-		),
-		people_categories: parse(
-			PeopleCategories,
-			await directus.request(readItems('people_categories'))
-		),
-		people_laboratories: parse(
-			PeopleLaboratories,
-			await directus.request(readItems('people_laboratories'))
-		),
-		laboratories: parse(Laboratories, await directus.request(readItems('laboratories')))
-	};
-	return schema;
-}
-
-async function obtainAssets(schema: Schema) {
-	const asset_urls = {
-		favicon: `${PUBLIC_APIURL}/assets/${schema.global.favicon}`
-	};
-
-	const assets = await Promise.allSettled(
-		Object.entries(asset_urls).map(([key, url]) =>
-			downloadData(url, key).then((path) => [key, path])
-		)
-	).then((results) =>
-		Object.fromEntries(
-			results.map((result, index) => {
-				const key = Object.keys(asset_urls)[index];
-				if (result.status === 'fulfilled') {
-					return result.value;
-				} else {
-					return [key, null];
-				}
-			})
-		)
-	);
-
-	// Ensure fallbacks for undefined assets
-	Object.keys(asset_urls).forEach((key) => {
-		if (!assets[key]) {
-			assets[key] = '/default/path/to/fallback.png'; // Replace with actual fallback
-		}
-	});
-
-	return assets;
-}
+import getDirectusInstance from '$lib/directus';
+import obtainSchema from '$lib/server/schema';
+import obtainAssets from '$lib/server/assets';
 
 export async function load({ fetch }) {
 	const directus = await getDirectusInstance(fetch);
-	const schema = await obtainSchema(directus);
-	const assets = await obtainAssets(schema);
+
+	const keys = ['global'];
+	const schema = await obtainSchema(directus, keys);
+
+	const asset_urls = {
+		favicon: `${PUBLIC_APIURL}/assets/${schema.global.favicon}`
+	};
+	const assets = await obtainAssets(asset_urls);
+
 	return { schema, assets };
 }

--- a/website-frontend/src/routes/+layout.svelte
+++ b/website-frontend/src/routes/+layout.svelte
@@ -3,7 +3,7 @@
 
 	export let data;
 
-	$: ({ global, assets } = data);
+	$: ({ title, favicon, description } = data);
 
 	import '../app.postcss';
 
@@ -27,13 +27,13 @@
 </script>
 
 <svelte:head>
-	<title>{global.title}</title>
-	<link rel="icon" href={assets.favicon} />
-	<meta name="description" content={global.description} />
+	<title>{title}</title>
+	<link rel="icon" href={favicon} />
+	<meta name="description" content={description} />
 </svelte:head>
 
 <header>
-	<Header {assets} />
+	<Header {favicon} />
 	<NavBar />
 </header>
 

--- a/website-frontend/src/routes/+layout.ts
+++ b/website-frontend/src/routes/+layout.ts
@@ -1,12 +1,8 @@
 /** @type {import('./$types').LayoutLoad} */
 export async function load({ data }) {
 	return {
-		global: data.schema.global,
-		events: data.schema.events,
-		student_council: data.schema.student_council,
-		alumni: data.schema.alumni,
-		linkages: data.schema.linkages,
-		laboratories: data.schema.laboratories,
-		assets: data.assets
+		title: data.schema.global.title,
+		description: data.schema.global.description,
+		favicon: data.assets.favicon
 	};
 }

--- a/website-frontend/src/routes/+page.server.ts
+++ b/website-frontend/src/routes/+page.server.ts
@@ -1,4 +1,4 @@
-/** @type {import('./$types').LayoutServerLoad} */
+/** @type {import('./$types').PageServerLoad} */
 import getDirectusInstance from '$lib/directus';
 import obtainSchema from '$lib/server/schema';
 

--- a/website-frontend/src/routes/+page.server.ts
+++ b/website-frontend/src/routes/+page.server.ts
@@ -1,0 +1,12 @@
+/** @type {import('./$types').LayoutServerLoad} */
+import getDirectusInstance from '$lib/directus';
+import obtainSchema from '$lib/server/schema';
+
+export async function load({ fetch }) {
+	const directus = await getDirectusInstance(fetch);
+
+	const keys = ['global', 'events'];
+	const schema = await obtainSchema(directus, keys);
+
+	return { schema };
+}

--- a/website-frontend/src/routes/+page.svelte
+++ b/website-frontend/src/routes/+page.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
+	/** @type {import('./$types').PageData} */
 	import { Event, Events } from '$lib/models/event';
 	import Hero from '$lib/components/landing/Hero.svelte';
 	import FeaturedEventCard from '$lib/components/events/FeaturedEventCard.svelte';
 
-	/** @type {import('./$types').PageData} */
 	export let data;
 
 	$: ({ title, description, events } = data);

--- a/website-frontend/src/routes/+page.svelte
+++ b/website-frontend/src/routes/+page.svelte
@@ -6,7 +6,7 @@
 	/** @type {import('./$types').PageData} */
 	export let data;
 
-	$: ({ global, events } = data);
+	$: ({ title, description, events } = data);
 
 	let sorted_events: Events = events;
 	$: sorted_events = events?.toSorted((e0: Event, e1: Event) => {
@@ -23,8 +23,8 @@
 
 <div class="container mx-auto my-8 h-full flex-col items-center justify-center">
 	<div class="space-y-5">
-		<h1 class="h1">{global.title}</h1>
-		<p>{global.description}</p>
+		<h1 class="h1">{title}</h1>
+		<p>{description}</p>
 	</div>
 	<div class="my-5">
 		<div class="flex justify-between">

--- a/website-frontend/src/routes/+page.ts
+++ b/website-frontend/src/routes/+page.ts
@@ -1,4 +1,4 @@
-/** @type {import('./$types').LayoutLoad} */
+/** @type {import('./$types').PageLoad} */
 export async function load({ data }) {
 	return {
 		title: data.schema.global.title,

--- a/website-frontend/src/routes/+page.ts
+++ b/website-frontend/src/routes/+page.ts
@@ -1,0 +1,8 @@
+/** @type {import('./$types').LayoutLoad} */
+export async function load({ data }) {
+	return {
+		title: data.schema.global.title,
+		description: data.schema.global.description,
+		events: data.schema.events
+	};
+}

--- a/website-frontend/src/routes/academics/+page.server.ts
+++ b/website-frontend/src/routes/academics/+page.server.ts
@@ -1,3 +1,4 @@
+/** @type {import('./$types').PageServerLoad} */
 const programs = [
 	{
 		slug: 'bs-cs',

--- a/website-frontend/src/routes/academics/+page.svelte
+++ b/website-frontend/src/routes/academics/+page.svelte
@@ -1,4 +1,5 @@
 <script>
+	/** @type {import('./$types').PageData} */
 	export let data;
 </script>
 

--- a/website-frontend/src/routes/academics/[slug]/+page.server.ts
+++ b/website-frontend/src/routes/academics/[slug]/+page.server.ts
@@ -1,3 +1,4 @@
+/** @type {import('./$types').PageServerLoad} */
 import { error } from '@sveltejs/kit';
 
 const programs = [

--- a/website-frontend/src/routes/academics/[slug]/+page.svelte
+++ b/website-frontend/src/routes/academics/[slug]/+page.svelte
@@ -1,4 +1,5 @@
 <script>
+	/** @type {import('./$types').PageData} */
 	export let data;
 </script>
 

--- a/website-frontend/src/routes/events/+page.server.ts
+++ b/website-frontend/src/routes/events/+page.server.ts
@@ -1,4 +1,4 @@
-/** @type {import('./$types').LayoutServerLoad} */
+/** @type {import('./$types').PageServerLoad} */
 import getDirectusInstance from '$lib/directus';
 import obtainSchema from '$lib/server/schema';
 

--- a/website-frontend/src/routes/events/+page.server.ts
+++ b/website-frontend/src/routes/events/+page.server.ts
@@ -1,0 +1,12 @@
+/** @type {import('./$types').LayoutServerLoad} */
+import getDirectusInstance from '$lib/directus';
+import obtainSchema from '$lib/server/schema';
+
+export async function load({ fetch }) {
+	const directus = await getDirectusInstance(fetch);
+
+	const keys = ['events'];
+	const schema = await obtainSchema(directus, keys);
+
+	return { schema };
+}

--- a/website-frontend/src/routes/events/+page.svelte
+++ b/website-frontend/src/routes/events/+page.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
+	/** @type {import('./$types').PageData} */
 	import { Event, Events } from '$lib/models/event';
 	import FeaturedEventCard from '$lib/components/events/FeaturedEventCard.svelte';
 
-	/** @type {import('./$types').PageData} */
 	export let data;
 
 	$: ({ events } = data);

--- a/website-frontend/src/routes/events/+page.ts
+++ b/website-frontend/src/routes/events/+page.ts
@@ -1,0 +1,6 @@
+/** @type {import('./$types').LayoutLoad} */
+export async function load({ data }) {
+	return {
+		events: data.schema.events
+	};
+}

--- a/website-frontend/src/routes/events/+page.ts
+++ b/website-frontend/src/routes/events/+page.ts
@@ -1,4 +1,4 @@
-/** @type {import('./$types').LayoutLoad} */
+/** @type {import('./$types').PageLoad} */
 export async function load({ data }) {
 	return {
 		events: data.schema.events

--- a/website-frontend/src/routes/people/+page.server.ts
+++ b/website-frontend/src/routes/people/+page.server.ts
@@ -1,3 +1,4 @@
+/** @type {import('./$types').PageServerLoad} */
 import { readItems, readSingleton } from '@directus/sdk';
 import { parse } from 'valibot';
 import { People } from '$lib/models/people';

--- a/website-frontend/src/routes/people/+page.svelte
+++ b/website-frontend/src/routes/people/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	/** @type {import('./$types').PageData} */
 	import Banner from '$lib/components/people/Banner.svelte';
 	import FilterControls from '$lib/components/people/FilterControls.svelte';
 	import PeopleCard from '$lib/components/people/PeopleCard.svelte';

--- a/website-frontend/src/routes/people/[slug]/+page.server.ts
+++ b/website-frontend/src/routes/people/[slug]/+page.server.ts
@@ -1,3 +1,4 @@
+/** @type {import('./$types').PageServerLoad} */
 import { readItems } from '@directus/sdk';
 import { parse } from 'valibot';
 import { People } from '$lib/models/people';

--- a/website-frontend/src/routes/people/[slug]/+page.svelte
+++ b/website-frontend/src/routes/people/[slug]/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	/** @type {import('./$types').PageData} */
 	import Banner from '$lib/components/people/Banner.svelte';
 	import FilterControls from '$lib/components/people/FilterControls.svelte';
 	import PeopleCard from '$lib/components/people/PeopleCard.svelte';

--- a/website-frontend/src/routes/people/[slug]/[username]/+page.server.ts
+++ b/website-frontend/src/routes/people/[slug]/[username]/+page.server.ts
@@ -1,3 +1,4 @@
+/** @type {import('./$types').PageServerLoad} */
 import { readItems } from '@directus/sdk';
 import { parse } from 'valibot';
 import { Person } from '$lib/models/people';

--- a/website-frontend/src/routes/people/[slug]/[username]/+page.svelte
+++ b/website-frontend/src/routes/people/[slug]/[username]/+page.svelte
@@ -1,4 +1,5 @@
 <script>
+	/** @type {import('./$types').PageData} */
 	import { PUBLIC_APIURL } from '$env/static/public';
 	export let data;
 	const { person, laboratories } = data;

--- a/website-frontend/src/routes/research/overview/+page.server.ts
+++ b/website-frontend/src/routes/research/overview/+page.server.ts
@@ -1,0 +1,11 @@
+import { readItems } from '@directus/sdk';
+import { parse } from 'valibot';
+import getDirectusInstance from '$lib/directus';
+import { Laboratories } from '$lib/models/laboratories.js';
+
+export async function load({ fetch }) {
+	const directus = await getDirectusInstance(fetch);
+	return {
+		laboratories: parse(Laboratories, await directus.request(readItems('laboratories')))
+	};
+}

--- a/website-frontend/src/routes/research/overview/+page.server.ts
+++ b/website-frontend/src/routes/research/overview/+page.server.ts
@@ -1,3 +1,4 @@
+/** @type {import('./$types').PageServerLoad} */
 import { readItems } from '@directus/sdk';
 import { parse } from 'valibot';
 import getDirectusInstance from '$lib/directus';


### PR DESCRIPTION
This PR limits data returns such that only the specified schema and assets will be requested from Directus CMS and eventually be used in the needed pages.

Requires:
- [x] #31