### PR TITLE
feat: use sort by recency as default for events

### DIFF
--- a/website-frontend/src/lib/server/schema.ts
+++ b/website-frontend/src/lib/server/schema.ts
@@ -10,7 +10,14 @@ import { parse } from 'valibot';
 async function obtainSchema(directus: RestClient<Schema>, keys: Array<string>) {
 	const schema = {
 		global: parse(Global, await directus.request(readSingleton('global'))),
-		events: parse(Events, await directus.request(readItems('events'))),
+		events: parse(
+			Events,
+			await directus.request(
+				readItems('events', {
+					sort: ['-date_created']
+				})
+			)
+		),
 		student_council: parse(
 			StudentCouncil,
 			await directus.request(readSingleton('student_council'))

--- a/website-frontend/src/routes/+page.svelte
+++ b/website-frontend/src/routes/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	/** @type {import('./$types').PageData} */
-	import { Event, Events } from '$lib/models/event';
 	import Hero from '$lib/components/landing/Hero.svelte';
 	import FeaturedEventCard from '$lib/components/events/FeaturedEventCard.svelte';
 
@@ -8,15 +7,7 @@
 
 	$: ({ title, description, events } = data);
 
-	let sorted_events: Events = events;
-	$: sorted_events = events?.toSorted((e0: Event, e1: Event) => {
-		let d0 = new Date(e0.date_created),
-			d1 = new Date(e1.date_created);
-		return d1.getTime() - d0.getTime();
-	});
-
-	let featured: Events = [];
-	$: featured = sorted_events?.slice(0, 3);
+	$: featured = events?.slice(0, 3);
 </script>
 
 <Hero />

--- a/website-frontend/src/routes/events/+page.svelte
+++ b/website-frontend/src/routes/events/+page.svelte
@@ -1,21 +1,12 @@
 <script lang="ts">
 	/** @type {import('./$types').PageData} */
-	import { Event, Events } from '$lib/models/event';
 	import FeaturedEventCard from '$lib/components/events/FeaturedEventCard.svelte';
 
 	export let data;
 
 	$: ({ events } = data);
 
-	let sorted_events: Events = events;
-	$: sorted_events = events?.toSorted((e0: Event, e1: Event) => {
-		let d0 = new Date(e0.date_created),
-			d1 = new Date(e1.date_created);
-		return d1.getTime() - d0.getTime();
-	});
-
-	let featured: Events = [];
-	$: featured = sorted_events?.slice(0, 3);
+	$: featured = events?.slice(0, 3);
 </script>
 
 <div class="container mx-auto my-8 h-full flex-col items-center justify-center">
@@ -25,7 +16,7 @@
 		{/each}
 	</div>
 	<div>
-		{#each sorted_events as event}
+		{#each events as event}
 			<div class="rounded border p-4 md:grid md:grid-cols-6">
 				<div class="md:col-span-5">
 					<h3>{event.event_headline}</h3>


### PR DESCRIPTION
This PR uses sort by recency as the default query parameter for fetching events in the home and events pages. This PR also utilizes Directus CMS query parameters to sort returned events automatically rather than sorting the events themselves in the frontend.

Requires:
- [ ] #31
- [ ] #33