### PR TITLE
fix: remove extraneous `Schema` type annotation

### DIFF
--- a/website-frontend/src/lib/server/schema.ts
+++ b/website-frontend/src/lib/server/schema.ts
@@ -26,7 +26,7 @@ async function obtainSchema(directus: RestClient<Schema>, keys: Array<string>) {
 		linkages: parse(Linkages, await directus.request(readSingleton('linkages')))
 	};
 
-	return Object.fromEntries(Object.entries(schema).filter(([key]) => keys.includes(key))) as Schema;
+	return Object.fromEntries(Object.entries(schema).filter(([key]) => keys.includes(key)));
 }
 
 export default obtainSchema;


### PR DESCRIPTION
This PR removes the extraneous `Schema` type annotation in `schema.ts`, resulting in `svelte-check` code quality workflow error.