### PR TITLE
fix: concat schema entries

### DIFF
--- a/website-frontend/src/lib/server/schema.ts
+++ b/website-frontend/src/lib/server/schema.ts
@@ -26,7 +26,9 @@ async function obtainSchema(directus: RestClient<Schema>, keys: Array<string>) {
 		linkages: parse(Linkages, await directus.request(readSingleton('linkages')))
 	};
 
-	return Object.fromEntries(Object.entries(schema).filter(([key]) => keys.includes(key)));
+	return Object.fromEntries(
+		Array(0).concat(Object.entries(schema).filter(([key]) => keys.includes(key)))
+	);
 }
 
 export default obtainSchema;


### PR DESCRIPTION
This PR fixes the `obtainSchema` return in `schema.ts` by concatenating entries from `Object.entries(schema).filter(...)` and then formulating the result as an object through `Object.fromEntries`.