### PR TITLE
feat!: use dotenv to handle environment variables

### DIFF
--- a/website-frontend/package.json
+++ b/website-frontend/package.json
@@ -3,6 +3,7 @@
 	"version": "0.0.1",
 	"private": true,
 	"scripts": {
+		"env:dev": "dotenv -e .env.development --",
 		"dev": "vite dev",
 		"build": "vite build",
 		"preview": "vite preview",
@@ -52,6 +53,7 @@
 	"type": "module",
 	"dependencies": {
 		"@directus/sdk": "^17.0.2",
+		"dotenv": "^16.4.7",
 		"dotenv-cli": "^8.0.0",
 		"embla-carousel-autoplay": "^8.5.1",
 		"highlight.js": "11.10.0",

--- a/website-frontend/package.json
+++ b/website-frontend/package.json
@@ -52,6 +52,7 @@
 	"type": "module",
 	"dependencies": {
 		"@directus/sdk": "^17.0.2",
+		"dotenv-cli": "^8.0.0",
 		"embla-carousel-autoplay": "^8.5.1",
 		"highlight.js": "11.10.0",
 		"sanitize-html": "^2.13.1",

--- a/website-frontend/pnpm-lock.yaml
+++ b/website-frontend/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@directus/sdk':
         specifier: ^17.0.2
         version: 17.0.2
+      dotenv-cli:
+        specifier: ^8.0.0
+        version: 8.0.0
       embla-carousel-autoplay:
         specifier: ^8.5.1
         version: 8.5.1(embla-carousel@8.5.1)
@@ -800,6 +803,18 @@ packages:
   domutils@3.1.0:
     resolution: {integrity: sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==}
 
+  dotenv-cli@8.0.0:
+    resolution: {integrity: sha512-aLqYbK7xKOiTMIRf1lDPbI+Y+Ip/wo5k3eyp6ePysVaSqbyxjyK3dK35BTxG+rmd7djf5q2UPs4noPNH+cj0Qw==}
+    hasBin: true
+
+  dotenv-expand@10.0.0:
+    resolution: {integrity: sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==}
+    engines: {node: '>=12'}
+
+  dotenv@16.4.7:
+    resolution: {integrity: sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==}
+    engines: {node: '>=12'}
+
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
@@ -1176,6 +1191,9 @@ packages:
   minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
@@ -2347,6 +2365,17 @@ snapshots:
       domelementtype: 2.3.0
       domhandler: 5.0.3
 
+  dotenv-cli@8.0.0:
+    dependencies:
+      cross-spawn: 7.0.6
+      dotenv: 16.4.7
+      dotenv-expand: 10.0.0
+      minimist: 1.2.8
+
+  dotenv-expand@10.0.0: {}
+
+  dotenv@16.4.7: {}
+
   eastasianwidth@0.2.0: {}
 
   electron-to-chromium@1.5.73: {}
@@ -2731,6 +2760,8 @@ snapshots:
   minimatch@9.0.5:
     dependencies:
       brace-expansion: 2.0.1
+
+  minimist@1.2.8: {}
 
   minipass@7.1.2: {}
 

--- a/website-frontend/pnpm-lock.yaml
+++ b/website-frontend/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@directus/sdk':
         specifier: ^17.0.2
         version: 17.0.2
+      dotenv:
+        specifier: ^16.4.7
+        version: 16.4.7
       dotenv-cli:
         specifier: ^8.0.0
         version: 8.0.0


### PR DESCRIPTION
This PR resolves some longstanding issues with missing environment variable exports during testing by providing an `env:dev` subcommand for `pnpm` to automatically export the environment file.

Please be aware that upon merging this feature, all `.env` files must be renamed `.env.development` to work with the specifications of the command.