### PR TITLE
feat: add `about_pages` model

### DIFF
--- a/website-frontend/src/lib/components/flexible_content/FlexibleContent.svelte
+++ b/website-frontend/src/lib/components/flexible_content/FlexibleContent.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+	import { enhanceWysiwygContent } from '.';
+	export let content: string = '';
+
+	$: enhancedContent = content ? enhanceWysiwygContent(content) : '';
+</script>
+
+{#if enhancedContent}
+	{@html enhancedContent}
+{/if}

--- a/website-frontend/src/lib/components/flexible_content/index.ts
+++ b/website-frontend/src/lib/components/flexible_content/index.ts
@@ -1,0 +1,33 @@
+const elementClassMap = {
+	p: 'mb-4',
+	h1: 'text-4xl font-bold mb-8',
+	h2: 'text-3xl font-bold mb-6',
+	h3: 'text-2xl font-bold mb-4',
+	strong: 'text-red-600 font-bold',
+	em: 'text-green-600 italic',
+	img: 'rounded-xl shadow-lg max-w-full h-auto mb-6 mx-auto',
+	a: 'text-blue-600 hover:text-blue-800 underline',
+	ul: 'list-disc list-inside pl-4 mb-4',
+	ol: 'list-decimal list-inside pl-4 mb-4',
+	li: 'mb-2',
+	blockquote: 'border-l-4 border-gray-300 pl-4 italic mb-4',
+	iframe: 'rounded-xl shadow-lg  mb-6 mx-auto'
+};
+
+export function enhanceWysiwygContent(htmlContent: string): string {
+	const parser = new DOMParser();
+	const doc = parser.parseFromString(htmlContent, 'text/html');
+
+	Object.entries(elementClassMap).forEach(([tag, className]) => {
+		const elements = doc.getElementsByTagName(tag);
+		Array.from(elements).forEach((element) => {
+			const existingClasses = element.getAttribute('class');
+			element.setAttribute(
+				'class',
+				existingClasses ? `${existingClasses} ${className}` : className
+			);
+		});
+	});
+
+	return doc.body.innerHTML;
+}

--- a/website-frontend/src/lib/components/nav/NavBar.svelte
+++ b/website-frontend/src/lib/components/nav/NavBar.svelte
@@ -23,7 +23,12 @@
 			<NavItem href="/" to="Home" />
 			<NavItem href="/about" to="About" dropdown={true}>
 				<NavItem href="/about" to="Overview" />
+				<NavItem href="/about/department" to="Department" />
+				<NavItem href="/about/administration" to="Administration" />
 				<NavItem href="/about/history" to="History" />
+				<NavItem href="/about/facts-and-figures" to="Facts and Figures" />
+				<NavItem href="/about/contact-us" to="Contact Us" />
+				<NavItem href="/about/citizens-charter" to="Citizen's Charter" />
 			</NavItem>
 			<NavItem href="/events" to="Events" />
 			<NavItem href="/people" to="People" dropdown={true}>

--- a/website-frontend/src/lib/models/about.ts
+++ b/website-frontend/src/lib/models/about.ts
@@ -1,0 +1,8 @@
+import { cleanHtml } from '$lib/models-helpers';
+import { object, pipe, string, type InferOutput } from 'valibot';
+
+export const About = object({
+	flexible_content: pipe(string(), cleanHtml)
+});
+
+export type About = InferOutput<typeof About>;

--- a/website-frontend/src/lib/models/about_pages.ts
+++ b/website-frontend/src/lib/models/about_pages.ts
@@ -1,0 +1,13 @@
+import { cleanHtml } from '$lib/models-helpers';
+import { array, object, pipe, string, type InferOutput } from 'valibot';
+
+export const AboutPage = object({
+	title: string(),
+	slug: string(),
+	flexible_content: pipe(string(), cleanHtml)
+});
+
+export const AboutPages = array(AboutPage);
+
+export type AboutPage = InferOutput<typeof AboutPage>;
+export type AboutPages = InferOutput<typeof AboutPages>;

--- a/website-frontend/src/lib/models/schema.ts
+++ b/website-frontend/src/lib/models/schema.ts
@@ -9,6 +9,7 @@ import { PeopleOverview } from './people_overview';
 import { PeopleCategories } from './people_categories';
 import { PeopleLaboratories } from './people_laboratories';
 import { Laboratories } from './laboratories';
+import { AboutPages } from './about_pages';
 
 export const Schema = object({
 	global: Global,
@@ -20,7 +21,8 @@ export const Schema = object({
 	people_overview: PeopleOverview,
 	people_categories: PeopleCategories,
 	people_laboratories: PeopleLaboratories,
-	laboratories: Laboratories
+	laboratories: Laboratories,
+	about_pages: AboutPages
 });
 
 export type Schema = InferOutput<typeof Schema>;

--- a/website-frontend/src/lib/models/schema.ts
+++ b/website-frontend/src/lib/models/schema.ts
@@ -9,6 +9,7 @@ import { PeopleOverview } from './people_overview';
 import { PeopleCategories } from './people_categories';
 import { PeopleLaboratories } from './people_laboratories';
 import { Laboratories } from './laboratories';
+import { About } from './about';
 import { AboutPages } from './about_pages';
 
 export const Schema = object({
@@ -22,6 +23,7 @@ export const Schema = object({
 	people_categories: PeopleCategories,
 	people_laboratories: PeopleLaboratories,
 	laboratories: Laboratories,
+	about: About,
 	about_pages: AboutPages
 });
 

--- a/website-frontend/src/routes/about/+page.server.ts
+++ b/website-frontend/src/routes/about/+page.server.ts
@@ -1,0 +1,12 @@
+/** @type {import('./$types').PageServerLoad} */
+import { readSingleton } from '@directus/sdk';
+import { parse } from 'valibot';
+import { About } from '$lib/models/about';
+import getDirectusInstance from '$lib/directus';
+
+export async function load({ fetch }) {
+	const directus = await getDirectusInstance(fetch);
+	return {
+		about: parse(About, await directus.request(readSingleton('about')))
+	};
+}

--- a/website-frontend/src/routes/about/+page.svelte
+++ b/website-frontend/src/routes/about/+page.svelte
@@ -3,26 +3,24 @@
 	import FlexibleContent from '$lib/components/flexible_content/FlexibleContent.svelte';
 	export let data;
 
-	$: ({ page } = data);
+	const { about } = data;
 </script>
 
 <body class="bg-gray-100">
-	{#if page}
+	{#if about}
 		<div class="relative">
 			<div
 				class="h-[40vh] bg-cover bg-center md:h-[50vh]"
 				style="background-image: linear-gradient(to top, #004420, transparent)"
 			></div>
 			<div class="absolute bottom-9">
-				<h1 class="px-4 text-3xl font-bold md:max-w-[60vw] md:px-32 md:text-5xl">
-					{page.title}
-				</h1>
+				<h1 class="px-4 text-3xl font-bold md:max-w-[60vw] md:px-32 md:text-5xl">About</h1>
 			</div>
 		</div>
 
-		<div class="px-4 py-10 text-base text-[#01152B] md:px-32">
-			{#if page.flexible_content}
-				<FlexibleContent content={page.flexible_content} />
+		<div class="prose px-4 py-10 text-base text-[#01152B] md:px-32">
+			{#if about.flexible_content}
+				<FlexibleContent content={about.flexible_content} />
 			{:else}
 				<p>Page is empty.</p>
 			{/if}

--- a/website-frontend/src/routes/about/[slug]/+page.server.ts
+++ b/website-frontend/src/routes/about/[slug]/+page.server.ts
@@ -1,0 +1,29 @@
+/** @type {import('./$types').PageServerLoad} */
+import { readItems } from '@directus/sdk';
+import getDirectusInstance from '$lib/directus';
+import { error } from '@sveltejs/kit';
+
+export async function load({ params, fetch }) {
+	const directus = await getDirectusInstance(fetch);
+	const slug = params.slug;
+
+	const pages = await directus.request(
+		readItems('about_pages', {
+			filter: {
+				slug: {
+					_eq: slug
+				}
+			}
+		})
+	);
+
+	if (!pages.length) {
+		throw error(404, 'Page not found');
+	}
+
+	const page = pages[0];
+
+	return {
+		page
+	};
+}

--- a/website-frontend/src/routes/about/[slug]/+page.svelte
+++ b/website-frontend/src/routes/about/[slug]/+page.svelte
@@ -1,0 +1,28 @@
+<script>
+	/** @type {import('./$types').PageData} */
+	export let data;
+
+	$: ({ page } = data);
+</script>
+
+<body class="bg-gray-100">
+	{#if page}
+		<div class="relative">
+			<div
+				class="h-[40vh] bg-cover bg-center md:h-[50vh]"
+				style="background-image: linear-gradient(to top, #004420, transparent)"
+			></div>
+			<div class="absolute bottom-9">
+				<h1 class="px-4 text-3xl font-bold md:max-w-[60vw] md:px-32 md:text-5xl">
+					{page.title}
+				</h1>
+			</div>
+		</div>
+
+		<div class="px-4 py-10 text-base text-[#01152B] md:px-32">
+			{@html page.flexible_content}
+		</div>
+	{:else}
+		<p>Page not found</p>
+	{/if}
+</body>

--- a/website-frontend/src/routes/about/[slug]/+page.svelte
+++ b/website-frontend/src/routes/about/[slug]/+page.svelte
@@ -20,7 +20,11 @@
 		</div>
 
 		<div class="px-4 py-10 text-base text-[#01152B] md:px-32">
-			{@html page.flexible_content}
+			{#if page.flexible_content}
+				{@html page.flexible_content}
+			{:else}
+				<p>Page is empty.</p>
+			{/if}
 		</div>
 	{:else}
 		<p>Page not found</p>


### PR DESCRIPTION
This PR includes significant updates to the `about` section and improve content rendering. This takes on tickets #66-#71 in Taiga.

### Enhancements to About Section:

* Added a server-side load function to fetch and parse the 'about' singleton from Directus.
* Created a new page component to display the about content using the `FlexibleContent` component.
* Added a server-side load function to fetch about pages by slug from Directus.
* Created a new page component to display about pages by slug using the `FlexibleContent` component.

### Flexible Content Enhancements:

* Added a new Svelte component to render enhanced WYSIWYG content.
* Introduced `enhanceWysiwygContent` function to apply styles to various HTML elements.

### Model Updates:

* Added a new `About` model to handle the about content with HTML cleaning.
* Added new `AboutPage` and `AboutPages` models to handle multiple about pages with HTML cleaning.

### Navigation Updates:

* Updated the navigation bar to include new links under the about section.