### PR TITLE
ci: set workflow run on `pull_request` only

### DIFF
--- a/.github/workflows/codequality.yml
+++ b/.github/workflows/codequality.yml
@@ -1,5 +1,5 @@
 name: Check Code Quality
-on: [push, pull_request_target]
+on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,5 +1,5 @@
 name: Playwright Tests
-on: [push, pull_request_target]
+on: [push, pull_request]
 jobs:
   test:
     timeout-minutes: 60


### PR DESCRIPTION
This PR sets workflow runs on `pull_request` to better represent status checks on created PRs.