### PR TITLE
fix: remove student_council singleton collection

### DIFF
--- a/website-frontend/src/lib/directus.ts
+++ b/website-frontend/src/lib/directus.ts
@@ -7,7 +7,7 @@ import type { Fetch } from './fetch';
 async function getDirectusInstance(fetch: Fetch | null) {
 	const options = fetch ? { globals: { fetch } } : {};
 	const directus = createDirectus<Schema>(PUBLIC_APIURL, options)
-		.with(authentication('session'))
+		.with(authentication('cookie'))
 		.with(rest());
 	await directus.login(EMAIL, PASSWORD);
 	return directus;

--- a/website-frontend/src/lib/directus.ts
+++ b/website-frontend/src/lib/directus.ts
@@ -7,7 +7,7 @@ import type { Fetch } from './fetch';
 async function getDirectusInstance(fetch: Fetch | null) {
 	const options = fetch ? { globals: { fetch } } : {};
 	const directus = createDirectus<Schema>(PUBLIC_APIURL, options)
-		.with(authentication('cookie'))
+		.with(authentication('session'))
 		.with(rest());
 	await directus.login(EMAIL, PASSWORD);
 	return directus;

--- a/website-frontend/src/lib/models/schema.ts
+++ b/website-frontend/src/lib/models/schema.ts
@@ -1,7 +1,6 @@
 import { object, type InferOutput } from 'valibot';
 import { Events } from './event';
 import { Global } from './global';
-import { StudentCouncil } from './student_council';
 import { Alumni } from './alumni';
 import { Linkages } from './linkages';
 import { People } from './people';
@@ -17,7 +16,6 @@ import { StudentsPages } from './students_pages';
 export const Schema = object({
 	global: Global,
 	events: Events,
-	student_council: StudentCouncil,
 	alumni: Alumni,
 	linkages: Linkages,
 	people: People,

--- a/website-frontend/src/lib/models/student_council.ts
+++ b/website-frontend/src/lib/models/student_council.ts
@@ -1,8 +1,0 @@
-import { cleanHtml } from '$lib/models-helpers';
-import { object, pipe, string, type InferOutput } from 'valibot';
-
-export const StudentCouncil = object({
-	flexible_content: pipe(string(), cleanHtml)
-});
-
-export type StudentCouncil = InferOutput<typeof StudentCouncil>;

--- a/website-frontend/src/lib/server/schema.ts
+++ b/website-frontend/src/lib/server/schema.ts
@@ -1,7 +1,6 @@
 import { Global } from '$lib/models/global';
 import { Events } from '$lib/models/event';
 import { Alumni } from '$lib/models/alumni';
-import { StudentCouncil } from '$lib/models/student_council';
 import { Linkages } from '$lib/models/linkages';
 import { type Schema } from '$lib/models/schema';
 import { type RestClient, readItems, readSingleton } from '@directus/sdk';
@@ -17,10 +16,6 @@ async function obtainSchema(directus: RestClient<Schema>, keys: Array<string>) {
 					sort: ['-date_created']
 				})
 			)
-		),
-		student_council: parse(
-			StudentCouncil,
-			await directus.request(readSingleton('student_council'))
 		),
 		alumni: parse(Alumni, await directus.request(readSingleton('alumni'))),
 		linkages: parse(Linkages, await directus.request(readSingleton('linkages')))

--- a/website-frontend/tests/collections.spec.ts
+++ b/website-frontend/tests/collections.spec.ts
@@ -2,7 +2,6 @@ import { test, expect } from '@playwright/test';
 import { parse } from 'valibot';
 import { Global } from '$lib/models/global';
 import { Events } from '$lib/models/event';
-import { StudentCouncil } from '$lib/models/student_council';
 
 test.describe('Directus Collections', () => {
 	test('Global', async ({ request }) => {
@@ -32,11 +31,6 @@ test.describe('Directus Collections', () => {
 			const test_request = await request.get(`${process.env.PUBLIC_APIURL}/items/students`);
 			expect(test_request.ok()).toBeTruthy();
 		});
-		test('Student Council', async ({ request }) => {
-			const test_request = await request.get(`${process.env.PUBLIC_APIURL}/items/student_council`);
-			expect(test_request.ok()).toBeTruthy();
-			expect(parse(StudentCouncil, (await test_request.json()).data)).toBeTruthy();
-		});
 	});
 
 	test('Publications', async ({ request }) => {
@@ -57,6 +51,5 @@ test.describe('Directus Collections', () => {
 	test('Alumni', async ({ request }) => {
 		const test_request = await request.get(`${process.env.PUBLIC_APIURL}/items/alumni`);
 		expect(test_request.ok()).toBeTruthy();
-		expect(parse(StudentCouncil, (await test_request.json()).data)).toBeTruthy();
 	});
 });


### PR DESCRIPTION
This PR removes the stale student_council singleton collection in the valibot parsing of schema and playwright testing.