### PR TITLE
feat: use static token for website auth

### DIFF
--- a/website-frontend/src/lib/components/events/DetailsBanner.svelte
+++ b/website-frontend/src/lib/components/events/DetailsBanner.svelte
@@ -5,7 +5,7 @@
 
 	export let title: string;
 	export let background_image: string;
-	export let location: string;
+	export let display_location: string;
 	export let start_date: string;
 	export let end_date: string;
 
@@ -67,10 +67,10 @@
 			<div class="text-white md:max-w-[60vw]">
 				<h1 class="text-4xl font-bold md:mb-4 md:text-4xl">{deslugify_title}</h1>
 				<div class="my-6 space-y-1 text-gray-100 md:my-0 md:flex">
-					{#if location}
+					{#if display_location}
 						<div class="flex items-center justify-center space-x-2 md:mr-10 md:justify-start">
 							<MapPin class="h-4 w-4" />
-							<h4>{@html location}</h4>
+							<h4>{@html display_location}</h4>
 						</div>
 					{/if}
 

--- a/website-frontend/src/lib/components/events/FeaturedEventCard.svelte
+++ b/website-frontend/src/lib/components/events/FeaturedEventCard.svelte
@@ -32,10 +32,10 @@
 				<Calendar class="h-4 w-4" />
 				<p>7 - 8 February 2025</p>
 			</div>
-			{#if event.location}
+			{#if event.display_location}
 				<div class="flex items-center space-x-2 text-sm text-gray-500">
 					<MapPin class="h-4 w-4" />
-					<p>{event.location}</p>
+					<p>{event.display_location}</p>
 				</div>
 			{/if}
 			{#if event.tags}

--- a/website-frontend/src/lib/directus.ts
+++ b/website-frontend/src/lib/directus.ts
@@ -7,7 +7,7 @@ import type { Fetch } from './fetch';
 async function getDirectusInstance(fetch: Fetch | null) {
 	const options = fetch ? { globals: { fetch } } : {};
 	const directus = createDirectus<Schema>(PUBLIC_APIURL, options)
-		.with(authentication('session'))
+		.with(authentication('cookie'))
 		.with(rest());
 	await directus.login(EMAIL, PASSWORD);
 	return directus;

--- a/website-frontend/src/lib/directus.ts
+++ b/website-frontend/src/lib/directus.ts
@@ -1,15 +1,14 @@
-import { createDirectus, rest, authentication } from '@directus/sdk';
-import { EMAIL, PASSWORD } from '$env/static/private';
+import { createDirectus, rest, staticToken } from '@directus/sdk';
+import { STATIC_ACCESS_TOKEN } from '$env/static/private';
 import { PUBLIC_APIURL } from '$env/static/public';
 import { type Schema } from './models/schema';
 import type { Fetch } from './fetch';
 
-async function getDirectusInstance(fetch: Fetch | null) {
+function getDirectusInstance(fetch: Fetch | null) {
 	const options = fetch ? { globals: { fetch } } : {};
 	const directus = createDirectus<Schema>(PUBLIC_APIURL, options)
-		.with(authentication('cookie'))
+		.with(staticToken(STATIC_ACCESS_TOKEN))
 		.with(rest());
-	await directus.login(EMAIL, PASSWORD);
 	return directus;
 }
 

--- a/website-frontend/src/lib/directus.ts
+++ b/website-frontend/src/lib/directus.ts
@@ -7,7 +7,7 @@ import type { Fetch } from './fetch';
 async function getDirectusInstance(fetch: Fetch | null) {
 	const options = fetch ? { globals: { fetch } } : {};
 	const directus = createDirectus<Schema>(PUBLIC_APIURL, options)
-		.with(authentication('cookie'))
+		.with(authentication('session'))
 		.with(rest());
 	await directus.login(EMAIL, PASSWORD);
 	return directus;

--- a/website-frontend/src/lib/models/event.ts
+++ b/website-frontend/src/lib/models/event.ts
@@ -19,7 +19,7 @@ export const Event = object({
 	tags: nullable(array(string())),
 	start_date: pipe(string(), isoTimestamp()),
 	end_date: nullable(pipe(string(), isoTimestamp())),
-	location: nullable(string())
+	display_location: nullable(string())
 });
 
 export const Events = array(Event);

--- a/website-frontend/src/lib/models/schema.ts
+++ b/website-frontend/src/lib/models/schema.ts
@@ -1,7 +1,6 @@
 import { object, type InferOutput } from 'valibot';
 import { Events } from './event';
 import { Global } from './global';
-import { StudentCouncil } from './student_council';
 import { Alumni } from './alumni';
 import { Linkages } from './linkages';
 import { People } from './people';
@@ -17,7 +16,6 @@ import { StudentsPages } from './students_pages';
 export const Schema = object({
 	global: Global,
 	events: Events,
-	student_council: StudentCouncil,
 	alumni: Alumni,
 	linkages: Linkages,
 	people: People,

--- a/website-frontend/src/lib/models/student_council.ts
+++ b/website-frontend/src/lib/models/student_council.ts
@@ -1,8 +1,0 @@
-import { cleanHtml } from '$lib/models-helpers';
-import { object, pipe, string, type InferOutput } from 'valibot';
-
-export const StudentCouncil = object({
-	flexible_content: pipe(string(), cleanHtml)
-});
-
-export type StudentCouncil = InferOutput<typeof StudentCouncil>;

--- a/website-frontend/src/lib/server/schema.ts
+++ b/website-frontend/src/lib/server/schema.ts
@@ -1,7 +1,6 @@
 import { Global } from '$lib/models/global';
 import { Events } from '$lib/models/event';
 import { Alumni } from '$lib/models/alumni';
-import { StudentCouncil } from '$lib/models/student_council';
 import { Linkages } from '$lib/models/linkages';
 import { type Schema } from '$lib/models/schema';
 import { type RestClient, readItems, readSingleton } from '@directus/sdk';
@@ -17,10 +16,6 @@ async function obtainSchema(directus: RestClient<Schema>, keys: Array<string>) {
 					sort: ['-date_created']
 				})
 			)
-		),
-		student_council: parse(
-			StudentCouncil,
-			await directus.request(readSingleton('student_council'))
 		),
 		alumni: parse(Alumni, await directus.request(readSingleton('alumni'))),
 		linkages: parse(Linkages, await directus.request(readSingleton('linkages')))

--- a/website-frontend/src/routes/+layout.server.ts
+++ b/website-frontend/src/routes/+layout.server.ts
@@ -3,7 +3,7 @@ import getDirectusInstance from '$lib/directus';
 import obtainSchema from '$lib/server/schema';
 
 export async function load({ fetch }) {
-	const directus = await getDirectusInstance(fetch);
+	const directus = getDirectusInstance(fetch);
 
 	const keys = ['global'];
 	const schema = await obtainSchema(directus, keys);

--- a/website-frontend/src/routes/+page.server.ts
+++ b/website-frontend/src/routes/+page.server.ts
@@ -3,7 +3,7 @@ import getDirectusInstance from '$lib/directus';
 import obtainSchema from '$lib/server/schema';
 
 export async function load({ fetch }) {
-	const directus = await getDirectusInstance(fetch);
+	const directus = getDirectusInstance(fetch);
 
 	const keys = ['global', 'events'];
 	const schema = await obtainSchema(directus, keys);

--- a/website-frontend/src/routes/about/+page.server.ts
+++ b/website-frontend/src/routes/about/+page.server.ts
@@ -5,7 +5,7 @@ import { About } from '$lib/models/about';
 import getDirectusInstance from '$lib/directus';
 
 export async function load({ fetch }) {
-	const directus = await getDirectusInstance(fetch);
+	const directus = getDirectusInstance(fetch);
 	return {
 		about: parse(About, await directus.request(readSingleton('about')))
 	};

--- a/website-frontend/src/routes/about/[slug]/+page.server.ts
+++ b/website-frontend/src/routes/about/[slug]/+page.server.ts
@@ -4,7 +4,7 @@ import getDirectusInstance from '$lib/directus';
 import { error } from '@sveltejs/kit';
 
 export async function load({ params, fetch }) {
-	const directus = await getDirectusInstance(fetch);
+	const directus = getDirectusInstance(fetch);
 	const slug = params.slug;
 
 	const pages = await directus.request(

--- a/website-frontend/src/routes/events/+page.server.ts
+++ b/website-frontend/src/routes/events/+page.server.ts
@@ -3,7 +3,7 @@ import getDirectusInstance from '$lib/directus';
 import obtainSchema from '$lib/server/schema';
 
 export async function load({ fetch }) {
-	const directus = await getDirectusInstance(fetch);
+	const directus = getDirectusInstance(fetch);
 
 	const keys = ['events'];
 	const schema = await obtainSchema(directus, keys);

--- a/website-frontend/src/routes/events/[slug]/+page.server.ts
+++ b/website-frontend/src/routes/events/[slug]/+page.server.ts
@@ -4,7 +4,7 @@ import getDirectusInstance from '$lib/directus';
 import { error } from '@sveltejs/kit';
 
 export async function load({ params, fetch }) {
-	const directus = await getDirectusInstance(fetch);
+	const directus = getDirectusInstance(fetch);
 	const eventSlug = params.slug;
 
 	const events = await directus.request(

--- a/website-frontend/src/routes/events/[slug]/+page.svelte
+++ b/website-frontend/src/routes/events/[slug]/+page.svelte
@@ -12,7 +12,7 @@
 			<DetailsBanner
 				title={event.event_headline}
 				background_image={event.hero_image ?? ''}
-				location={event.location ?? ''}
+				display_location={event.display_location ?? ''}
 				start_date={event.start_date}
 				end_date={event.end_date ?? ''}
 			/>

--- a/website-frontend/src/routes/people/+page.server.ts
+++ b/website-frontend/src/routes/people/+page.server.ts
@@ -6,7 +6,7 @@ import { PeopleOverview } from '$lib/models/people_overview';
 import getDirectusInstance from '$lib/directus';
 
 export async function load({ fetch }) {
-	const directus = await getDirectusInstance(fetch);
+	const directus = getDirectusInstance(fetch);
 	return {
 		people: parse(People, await directus.request(readItems('people'))),
 		people_overview: parse(PeopleOverview, await directus.request(readSingleton('people_overview')))

--- a/website-frontend/src/routes/people/[slug]/+page.server.ts
+++ b/website-frontend/src/routes/people/[slug]/+page.server.ts
@@ -6,7 +6,7 @@ import getDirectusInstance from '$lib/directus';
 import { error } from '@sveltejs/kit';
 
 export async function load({ params, fetch }) {
-	const directus = await getDirectusInstance(fetch);
+	const directus = getDirectusInstance(fetch);
 	const categorySlug = params.slug;
 
 	const categories = await directus.request(

--- a/website-frontend/src/routes/people/[slug]/[username]/+page.server.ts
+++ b/website-frontend/src/routes/people/[slug]/[username]/+page.server.ts
@@ -6,7 +6,7 @@ import getDirectusInstance from '$lib/directus';
 import { error } from '@sveltejs/kit';
 
 export async function load({ params, fetch }) {
-	const directus = await getDirectusInstance(fetch);
+	const directus = getDirectusInstance(fetch);
 	const username = params.username;
 
 	const people = await directus.request(

--- a/website-frontend/src/routes/research/+page.server.ts
+++ b/website-frontend/src/routes/research/+page.server.ts
@@ -5,7 +5,7 @@ import getDirectusInstance from '$lib/directus';
 import { Laboratories } from '$lib/models/laboratories.js';
 
 export async function load({ fetch }) {
-	const directus = await getDirectusInstance(fetch);
+	const directus = getDirectusInstance(fetch);
 	return {
 		laboratories: parse(Laboratories, await directus.request(readItems('laboratories')))
 	};

--- a/website-frontend/src/routes/students/+page.server.ts
+++ b/website-frontend/src/routes/students/+page.server.ts
@@ -5,7 +5,7 @@ import { StudentsOverview } from '$lib/models/students_overview.js';
 import getDirectusInstance from '$lib/directus';
 
 export async function load({ fetch }) {
-	const directus = await getDirectusInstance(fetch);
+	const directus = getDirectusInstance(fetch);
 	return {
 		students_overview: parse(
 			StudentsOverview,

--- a/website-frontend/src/routes/students/[slug]/+page.server.ts
+++ b/website-frontend/src/routes/students/[slug]/+page.server.ts
@@ -4,7 +4,7 @@ import getDirectusInstance from '$lib/directus';
 import { error } from '@sveltejs/kit';
 
 export async function load({ params, fetch }) {
-	const directus = await getDirectusInstance(fetch);
+	const directus = getDirectusInstance(fetch);
 	const slug = params.slug;
 
 	const pages = await directus.request(

--- a/website-frontend/src/routes/students/organizations/+page.server.ts
+++ b/website-frontend/src/routes/students/organizations/+page.server.ts
@@ -3,7 +3,7 @@ import { readItem } from '@directus/sdk';
 import getDirectusInstance from '$lib/directus';
 
 export async function load({ fetch }) {
-	const directus = await getDirectusInstance(fetch);
+	const directus = getDirectusInstance(fetch);
 	const page = await directus.request(readItem('students_pages', 4));
 
 	return {

--- a/website-frontend/tests/collections.spec.ts
+++ b/website-frontend/tests/collections.spec.ts
@@ -2,7 +2,6 @@ import { test, expect } from '@playwright/test';
 import { parse } from 'valibot';
 import { Global } from '$lib/models/global';
 import { Events } from '$lib/models/event';
-import { StudentCouncil } from '$lib/models/student_council';
 
 test.describe('Directus Collections', () => {
 	test('Global', async ({ request }) => {
@@ -32,11 +31,6 @@ test.describe('Directus Collections', () => {
 			const test_request = await request.get(`${process.env.PUBLIC_APIURL}/items/students`);
 			expect(test_request.ok()).toBeTruthy();
 		});
-		test('Student Council', async ({ request }) => {
-			const test_request = await request.get(`${process.env.PUBLIC_APIURL}/items/student_council`);
-			expect(test_request.ok()).toBeTruthy();
-			expect(parse(StudentCouncil, (await test_request.json()).data)).toBeTruthy();
-		});
 	});
 
 	test('Publications', async ({ request }) => {
@@ -57,6 +51,5 @@ test.describe('Directus Collections', () => {
 	test('Alumni', async ({ request }) => {
 		const test_request = await request.get(`${process.env.PUBLIC_APIURL}/items/alumni`);
 		expect(test_request.ok()).toBeTruthy();
-		expect(parse(StudentCouncil, (await test_request.json()).data)).toBeTruthy();
 	});
 });


### PR DESCRIPTION
This PR sets the website's authentication method to use a static token for extended use. As such, the developers and maintainers should set the correct value for the private environment variable STATIC_ACCESS_TOKEN.

This PR also tries to resolve the 502 Bad Gateway error thrown by PUBLIC_APIURL/auth/login while using the website for an extended time.