### PR TITLE
ci: add static token to code quality workflow

### DIFF
--- a/.github/workflows/codequality.yml
+++ b/.github/workflows/codequality.yml
@@ -30,6 +30,5 @@ jobs:
         if: ${{ !cancelled() }}
         run: pnpm run check
         env:
-          EMAIL: ${{ secrets.EMAIL }}
-          PASSWORD: ${{ secrets.PASSWORD }}
+          STATIC_ACCESS_TOKEN: ${{ secrets.STATIC_ACCESS_TOKEN }}
           PUBLIC_APIURL: ${{ vars.PUBLIC_APIURL }}


### PR DESCRIPTION
This PR adds access to `STATIC_ACCESS_TOKEN` to the code quality workflow.