### PR TITLE
refactor: reinforce parse validation to `.server.ts` files

### DIFF
--- a/website-frontend/src/lib/models-helpers.ts
+++ b/website-frontend/src/lib/models-helpers.ts
@@ -3,8 +3,5 @@ import { transform } from 'valibot';
 
 export const cleanHtml = transform((input: string) => sanitize(input));
 export const toDateTime = transform((input: string) => {
-	if (!isNaN(Date.parse(input))) {
-		return input as 'datetime';
-	}
-	return Date.now().toString() as 'datetime';
+	return input as 'datetime';
 });

--- a/website-frontend/src/routes/+layout.server.ts
+++ b/website-frontend/src/routes/+layout.server.ts
@@ -1,10 +1,12 @@
 /** @type {import('./$types').PageServerLoad} */
 import { readSingleton } from '@directus/sdk';
 import getDirectusInstance from '$lib/directus';
+import { Global } from '$lib/models/global';
+import { parse } from 'valibot';
 
 export async function load({ fetch }) {
 	const directus = getDirectusInstance(fetch);
-	const global = await directus.request(readSingleton('global'));
+	const global = parse(Global, await directus.request(readSingleton('global')));
 
 	return { global };
 }

--- a/website-frontend/src/routes/+page.server.ts
+++ b/website-frontend/src/routes/+page.server.ts
@@ -1,11 +1,14 @@
 /** @type {import('./$types').PageServerLoad} */
 import { readItems, readSingleton } from '@directus/sdk';
 import getDirectusInstance from '$lib/directus';
+import { Global } from '$lib/models/global';
+import { Events } from '$lib/models/event';
+import { parse } from 'valibot';
 
 export async function load({ fetch }) {
 	const directus = getDirectusInstance(fetch);
-	const global = await directus.request(readSingleton('global'));
-	const events = await directus.request(readItems('events'));
+	const global = parse(Global, await directus.request(readSingleton('global')));
+	const events = parse(Events, await directus.request(readItems('events')));
 
 	return { global, events };
 }

--- a/website-frontend/src/routes/about/+page.server.ts
+++ b/website-frontend/src/routes/about/+page.server.ts
@@ -1,12 +1,12 @@
 /** @type {import('./$types').PageServerLoad} */
 import { readSingleton } from '@directus/sdk';
-import { parse } from 'valibot';
-import { About } from '$lib/models/about';
 import getDirectusInstance from '$lib/directus';
+import { About } from '$lib/models/about';
+import { parse } from 'valibot';
 
 export async function load({ fetch }) {
 	const directus = getDirectusInstance(fetch);
-	return {
-		about: parse(About, await directus.request(readSingleton('about')))
-	};
+	const about = parse(About, await directus.request(readSingleton('about')));
+
+	return { about };
 }

--- a/website-frontend/src/routes/about/[slug]/+page.server.ts
+++ b/website-frontend/src/routes/about/[slug]/+page.server.ts
@@ -1,29 +1,32 @@
 /** @type {import('./$types').PageServerLoad} */
 import { readItems } from '@directus/sdk';
 import getDirectusInstance from '$lib/directus';
+import { AboutPage, AboutPages } from '$lib/models/about_pages';
 import { error } from '@sveltejs/kit';
+import { parse } from 'valibot';
 
 export async function load({ params, fetch }) {
 	const directus = getDirectusInstance(fetch);
 	const slug = params.slug;
 
-	const pages = await directus.request(
-		readItems('about_pages', {
-			filter: {
-				slug: {
-					_eq: slug
+	const pages = parse(
+		AboutPages,
+		await directus.request(
+			readItems('about_pages', {
+				filter: {
+					slug: {
+						_eq: slug
+					}
 				}
-			}
-		})
+			})
+		)
 	);
 
 	if (!pages.length) {
 		throw error(404, 'Page not found');
 	}
 
-	const page = pages[0];
+	const page = parse(AboutPage, pages[0]);
 
-	return {
-		page
-	};
+	return { page };
 }

--- a/website-frontend/src/routes/events/+page.server.ts
+++ b/website-frontend/src/routes/events/+page.server.ts
@@ -1,6 +1,6 @@
 /** @type {import('./$types').PageServerLoad} */
 import getDirectusInstance from '$lib/directus';
-import { Events } from '$lib/models/event.js';
+import { Events } from '$lib/models/event';
 import { readItems } from '@directus/sdk';
 import { parse } from 'valibot';
 

--- a/website-frontend/src/routes/events/[slug]/+page.server.ts
+++ b/website-frontend/src/routes/events/[slug]/+page.server.ts
@@ -1,20 +1,25 @@
 /** @type {import('./$types').PageServerLoad} */
 import { readItems } from '@directus/sdk';
 import getDirectusInstance from '$lib/directus';
+import { Events } from '$lib/models/event';
 import { error } from '@sveltejs/kit';
+import { parse } from 'valibot';
 
 export async function load({ params, fetch }) {
 	const directus = getDirectusInstance(fetch);
 	const eventSlug = params.slug;
 
-	const events = await directus.request(
-		readItems('events', {
-			filter: {
-				slug: {
-					_eq: eventSlug
+	const events = parse(
+		Events,
+		await directus.request(
+			readItems('events', {
+				filter: {
+					slug: {
+						_eq: eventSlug
+					}
 				}
-			}
-		})
+			})
+		)
 	);
 
 	if (!events.length) {

--- a/website-frontend/src/routes/people/+page.server.ts
+++ b/website-frontend/src/routes/people/+page.server.ts
@@ -1,14 +1,17 @@
 /** @type {import('./$types').PageServerLoad} */
 import { readItems, readSingleton } from '@directus/sdk';
-import { parse } from 'valibot';
+import getDirectusInstance from '$lib/directus';
 import { People } from '$lib/models/people';
 import { PeopleOverview } from '$lib/models/people_overview';
-import getDirectusInstance from '$lib/directus';
+import { parse } from 'valibot';
 
 export async function load({ fetch }) {
 	const directus = getDirectusInstance(fetch);
-	return {
-		people: parse(People, await directus.request(readItems('people'))),
-		people_overview: parse(PeopleOverview, await directus.request(readSingleton('people_overview')))
-	};
+	const people = parse(People, await directus.request(readItems('people')));
+	const people_overview = parse(
+		PeopleOverview,
+		await directus.request(readSingleton('people_overview'))
+	);
+
+	return { people, people_overview };
 }

--- a/website-frontend/src/routes/people/[slug]/+page.server.ts
+++ b/website-frontend/src/routes/people/[slug]/+page.server.ts
@@ -1,22 +1,26 @@
 /** @type {import('./$types').PageServerLoad} */
 import { readItems } from '@directus/sdk';
-import { parse } from 'valibot';
-import { People } from '$lib/models/people';
 import getDirectusInstance from '$lib/directus';
+import { People } from '$lib/models/people';
+import { PeopleCategories } from '$lib/models/people_categories';
+import { parse } from 'valibot';
 import { error } from '@sveltejs/kit';
 
 export async function load({ params, fetch }) {
 	const directus = getDirectusInstance(fetch);
 	const categorySlug = params.slug;
 
-	const categories = await directus.request(
-		readItems('people_categories', {
-			filter: {
-				title: {
-					_eq: categorySlug
+	const categories = parse(
+		PeopleCategories,
+		await directus.request(
+			readItems('people_categories', {
+				filter: {
+					title: {
+						_eq: categorySlug
+					}
 				}
-			}
-		})
+			})
+		)
 	);
 
 	if (!categories.length) {
@@ -38,8 +42,5 @@ export async function load({ params, fetch }) {
 		)
 	);
 
-	return {
-		category,
-		people
-	};
+	return { category, people };
 }

--- a/website-frontend/src/routes/people/[slug]/[username]/+page.server.ts
+++ b/website-frontend/src/routes/people/[slug]/[username]/+page.server.ts
@@ -1,21 +1,26 @@
 /** @type {import('./$types').PageServerLoad} */
 import { readItems } from '@directus/sdk';
-import { parse } from 'valibot';
-import { Person } from '$lib/models/people';
 import getDirectusInstance from '$lib/directus';
+import { People, Person } from '$lib/models/people';
+import { PeopleLaboratories } from '$lib/models/people_laboratories';
+import { Laboratories } from '$lib/models/laboratories';
+import { parse } from 'valibot';
 import { error } from '@sveltejs/kit';
 
 export async function load({ params, fetch }) {
 	const directus = getDirectusInstance(fetch);
 	const username = params.username;
 
-	const people = await directus.request(
-		readItems('people', {
-			filter: {
-				username: { _eq: username }
-			},
-			limit: 1
-		})
+	const people = parse(
+		People,
+		await directus.request(
+			readItems('people', {
+				filter: {
+					username: { _eq: username }
+				},
+				limit: 1
+			})
+		)
 	);
 
 	if (!people || people.length === 0) {
@@ -24,28 +29,33 @@ export async function load({ params, fetch }) {
 
 	const personId = people[0].id;
 
-	const labAssociations = await directus.request(
-		readItems('people_laboratories', {
-			filter: {
-				people_id: { _eq: personId }
-			}
-		})
+	const labAssociations = parse(
+		PeopleLaboratories,
+		await directus.request(
+			readItems('people_laboratories', {
+				filter: {
+					people_id: { _eq: personId }
+				}
+			})
+		)
 	);
 
 	const laboratoryIds = labAssociations.map((assoc) => assoc.laboratories_id);
 	const laboratories =
 		laboratoryIds.length > 0
-			? await directus.request(
-					readItems('laboratories', {
-						filter: {
-							id: { _in: laboratoryIds }
-						}
-					})
+			? parse(
+					Laboratories,
+					await directus.request(
+						readItems('laboratories', {
+							filter: {
+								id: { _in: laboratoryIds }
+							}
+						})
+					)
 				)
 			: [];
 
-	return {
-		person: parse(Person, people[0]),
-		laboratories
-	};
+	const person = parse(Person, people[0]);
+
+	return { person, laboratories };
 }

--- a/website-frontend/src/routes/research/+page.server.ts
+++ b/website-frontend/src/routes/research/+page.server.ts
@@ -1,12 +1,12 @@
 /** @type {import('./$types').PageServerLoad} */
 import { readItems } from '@directus/sdk';
-import { parse } from 'valibot';
 import getDirectusInstance from '$lib/directus';
-import { Laboratories } from '$lib/models/laboratories.js';
+import { Laboratories } from '$lib/models/laboratories';
+import { parse } from 'valibot';
 
 export async function load({ fetch }) {
 	const directus = getDirectusInstance(fetch);
-	return {
-		laboratories: parse(Laboratories, await directus.request(readItems('laboratories')))
-	};
+	const laboratories = parse(Laboratories, await directus.request(readItems('laboratories')));
+
+	return { laboratories };
 }

--- a/website-frontend/src/routes/students/+page.server.ts
+++ b/website-frontend/src/routes/students/+page.server.ts
@@ -1,15 +1,15 @@
 /** @type {import('./$types').PageServerLoad} */
 import { readSingleton } from '@directus/sdk';
-import { parse } from 'valibot';
-import { StudentsOverview } from '$lib/models/students_overview.js';
 import getDirectusInstance from '$lib/directus';
+import { StudentsOverview } from '$lib/models/students_overview';
+import { parse } from 'valibot';
 
 export async function load({ fetch }) {
 	const directus = getDirectusInstance(fetch);
-	return {
-		students_overview: parse(
-			StudentsOverview,
-			await directus.request(readSingleton('students_overview'))
-		)
-	};
+	const students_overview = parse(
+		StudentsOverview,
+		await directus.request(readSingleton('students_overview'))
+	);
+
+	return { students_overview };
 }

--- a/website-frontend/src/routes/students/[slug]/+page.server.ts
+++ b/website-frontend/src/routes/students/[slug]/+page.server.ts
@@ -1,20 +1,25 @@
 /** @type {import('./$types').PageServerLoad} */
 import { readItems } from '@directus/sdk';
 import getDirectusInstance from '$lib/directus';
+import { StudentsPages } from '$lib/models/students_pages';
+import { parse } from 'valibot';
 import { error } from '@sveltejs/kit';
 
 export async function load({ params, fetch }) {
 	const directus = getDirectusInstance(fetch);
 	const slug = params.slug;
 
-	const pages = await directus.request(
-		readItems('students_pages', {
-			filter: {
-				slug: {
-					_eq: slug
+	const pages = parse(
+		StudentsPages,
+		await directus.request(
+			readItems('students_pages', {
+				filter: {
+					slug: {
+						_eq: slug
+					}
 				}
-			}
-		})
+			})
+		)
 	);
 
 	if (!pages.length) {
@@ -23,7 +28,5 @@ export async function load({ params, fetch }) {
 
 	const page = pages[0];
 
-	return {
-		page
-	};
+	return { page };
 }

--- a/website-frontend/src/routes/students/organizations/+page.server.ts
+++ b/website-frontend/src/routes/students/organizations/+page.server.ts
@@ -1,12 +1,12 @@
 /** @type {import('./$types').PageServerLoad} */
 import { readItem } from '@directus/sdk';
 import getDirectusInstance from '$lib/directus';
+import { StudentsPage } from '$lib/models/students_pages';
+import { parse } from 'valibot';
 
 export async function load({ fetch }) {
 	const directus = getDirectusInstance(fetch);
-	const page = await directus.request(readItem('students_pages', 4));
+	const page = parse(StudentsPage, await directus.request(readItem('students_pages', 4)));
 
-	return {
-		page
-	};
+	return { page };
 }


### PR DESCRIPTION
This PR reinforces parse validation to `.server.ts` files, utilizing defined valibot models for output validation from Directus.