### PR TITLE
feat: use M2M event tags for related events

### DIFF
--- a/website-frontend/src/lib/components/events/FeaturedEventCard.svelte
+++ b/website-frontend/src/lib/components/events/FeaturedEventCard.svelte
@@ -38,10 +38,10 @@
 					<p>{event.display_location}</p>
 				</div>
 			{/if}
-			{#if event.tags}
+			{#if event.event_tags}
 				<div class="py-1 text-xs font-bold text-gray-600">
-					{#each event.tags as tag, index}
-						<p>{tag}{index < event.tags.length - 1 ? ',' : ''}</p>
+					{#each event.event_tags as tag, index}
+						<p>{tag.events_tags_id.name}{index < event.event_tags.length - 1 ? ',' : ''}</p>
 					{/each}
 				</div>
 			{/if}

--- a/website-frontend/src/lib/models/event.ts
+++ b/website-frontend/src/lib/models/event.ts
@@ -1,6 +1,7 @@
 import { cleanHtml, toDateTime } from '$lib/models-helpers';
 import {
 	array,
+	intersect,
 	isoTimestamp,
 	nullable,
 	number,
@@ -11,7 +12,7 @@ import {
 	type InferOutput
 } from 'valibot';
 
-export const Event = object({
+const BaseEvent = object({
 	id: number(),
 	slug: string(),
 	date_created: pipe(string(), isoTimestamp()),
@@ -25,7 +26,30 @@ export const Event = object({
 	display_location: nullable(string())
 });
 
+const BaseEventTags = object({
+	event_tags: array(string())
+});
+
+const NestedEventTags = object({
+	event_tags: array(
+		object({
+			events_tags_id: object({
+				related_events: array(
+					object({
+						events_id: intersect([BaseEvent, BaseEventTags])
+					})
+				)
+			})
+		})
+	)
+});
+
+export const Event = intersect([BaseEvent, BaseEventTags]);
 export const Events = array(Event);
+export const NestedEvent = intersect([BaseEvent, NestedEventTags]);
+export const NestedEvents = array(NestedEvent);
 
 export type Event = InferOutput<typeof Event>;
 export type Events = InferOutput<typeof Events>;
+export type NestedEvent = InferOutput<typeof NestedEvent>;
+export type NestedEvents = InferOutput<typeof NestedEvents>;

--- a/website-frontend/src/lib/models/event.ts
+++ b/website-frontend/src/lib/models/event.ts
@@ -27,13 +27,20 @@ const BaseEvent = object({
 });
 
 const BaseEventTags = object({
-	event_tags: array(string())
+	event_tags: array(
+		object({
+			events_tags_id: object({
+				name: string()
+			})
+		})
+	)
 });
 
 const NestedEventTags = object({
 	event_tags: array(
 		object({
 			events_tags_id: object({
+				name: string(),
 				related_events: array(
 					object({
 						events_id: intersect([BaseEvent, BaseEventTags])

--- a/website-frontend/src/routes/+page.server.ts
+++ b/website-frontend/src/routes/+page.server.ts
@@ -5,7 +5,9 @@ import getDirectusInstance from '$lib/directus';
 export async function load({ fetch }) {
 	const directus = getDirectusInstance(fetch);
 	const global = await directus.request(readSingleton('global'));
-	const events = await directus.request(readItems('events'));
+	const events = await directus.request(
+		readItems('events', { fields: ['*', 'event_tags.events_tags_id.name'] })
+	);
 
 	return { global, events };
 }

--- a/website-frontend/src/routes/events/+page.server.ts
+++ b/website-frontend/src/routes/events/+page.server.ts
@@ -1,6 +1,6 @@
 /** @type {import('./$types').PageServerLoad} */
 import getDirectusInstance from '$lib/directus';
-import { Events } from '$lib/models/event.js';
+import { Events } from '$lib/models/event';
 import { readItems } from '@directus/sdk';
 import { parse } from 'valibot';
 

--- a/website-frontend/src/routes/events/+page.server.ts
+++ b/website-frontend/src/routes/events/+page.server.ts
@@ -26,6 +26,7 @@ export async function load({ fetch, url }) {
 				Events,
 				await directus.request(
 					readItems('events', {
+						fields: ['*', 'event_tags.events_tags_id.name'],
 						filter: {
 							_and: [
 								{ event_area: { _in: locations } },
@@ -64,6 +65,7 @@ export async function load({ fetch, url }) {
 				Events,
 				await directus.request(
 					readItems('events', {
+						fields: ['*', 'event_tags.events_tags_id.name'],
 						filter: { event_area: { _in: locations } }
 					})
 				)
@@ -73,6 +75,7 @@ export async function load({ fetch, url }) {
 			Events,
 			await directus.request(
 				readItems('events', {
+					fields: ['*', 'event_tags.events_tags_id.name'],
 					filter: {
 						_and: [
 							{ event_area: { _in: locations } },

--- a/website-frontend/src/routes/events/[slug]/+page.server.ts
+++ b/website-frontend/src/routes/events/[slug]/+page.server.ts
@@ -13,7 +13,12 @@ export async function load({ params, fetch }) {
 		NestedEvents,
 		await directus.request(
 			readItems('events', {
-				fields: ['*', 'event_tags.events_tags_id.related_events.events_id.*'],
+				fields: [
+					'*',
+					'event_tags.events_tags_id.name',
+					'event_tags.events_tags_id.related_events.events_id.*',
+					'event_tags.events_tags_id.related_events.events_id.event_tags.events_tags_id.name'
+				],
 				filter: {
 					slug: {
 						_eq: eventSlug

--- a/website-frontend/src/routes/events/[slug]/+page.server.ts
+++ b/website-frontend/src/routes/events/[slug]/+page.server.ts
@@ -40,6 +40,7 @@ export async function load({ params, fetch }) {
 			return event_tags
 				.filter(
 					({ events_id }, index) =>
+						events_id.id != event.id &&
 						!event_tags.map(({ events_id }) => events_id.id).includes(events_id.id, index + 1)
 				)
 				.map((res) => res.events_id);

--- a/website-frontend/src/routes/events/[slug]/+page.server.ts
+++ b/website-frontend/src/routes/events/[slug]/+page.server.ts
@@ -2,7 +2,7 @@
 import { readItems } from '@directus/sdk';
 import getDirectusInstance from '$lib/directus';
 import { error } from '@sveltejs/kit';
-import { Events } from '$lib/models/event';
+import { NestedEvents } from '$lib/models/event';
 import { parse } from 'valibot';
 
 export async function load({ params, fetch }) {
@@ -10,9 +10,10 @@ export async function load({ params, fetch }) {
 	const eventSlug = params.slug;
 
 	const events = parse(
-		Events,
+		NestedEvents,
 		await directus.request(
 			readItems('events', {
+				fields: ['*', 'event_tags.events_tags_id.related_events.events_id.*'],
 				filter: {
 					slug: {
 						_eq: eventSlug
@@ -27,29 +28,16 @@ export async function load({ params, fetch }) {
 	}
 
 	const event = events[0];
+	const event_tags = event.event_tags.map((item) => item.events_tags_id.related_events).flat();
 
 	const related_events = await (async () => {
-		if (event.tags) {
-			return parse(
-				Events,
-				await directus
-					.request(
-						readItems('events', {
-							filter: {
-								id: {
-									_neq: event.id
-								}
-							}
-						})
-					)
-					.then((res) =>
-						res.filter((item) => {
-							const item_tags = new Set(item.tags);
-							const event_tags = new Set(event.tags);
-							return item_tags.intersection(event_tags).size !== 0;
-						})
-					)
-			);
+		if (event.event_tags.length != 0) {
+			return event_tags
+				.filter(
+					({ events_id }, index) =>
+						!event_tags.map(({ events_id }) => events_id.id).includes(events_id.id, index + 1)
+				)
+				.map((res) => res.events_id);
 		}
 		return [];
 	})();

--- a/website-frontend/src/routes/research/+page.server.ts
+++ b/website-frontend/src/routes/research/+page.server.ts
@@ -2,7 +2,7 @@
 import { readItems } from '@directus/sdk';
 import { parse } from 'valibot';
 import getDirectusInstance from '$lib/directus';
-import { Laboratories } from '$lib/models/laboratories.js';
+import { Laboratories } from '$lib/models/laboratories';
 
 export async function load({ fetch }) {
 	const directus = getDirectusInstance(fetch);

--- a/website-frontend/src/routes/students/+page.server.ts
+++ b/website-frontend/src/routes/students/+page.server.ts
@@ -1,7 +1,7 @@
 /** @type {import('./$types').PageServerLoad} */
 import { readSingleton } from '@directus/sdk';
 import { parse } from 'valibot';
-import { StudentsOverview } from '$lib/models/students_overview.js';
+import { StudentsOverview } from '$lib/models/students_overview';
 import getDirectusInstance from '$lib/directus';
 
 export async function load({ fetch }) {


### PR DESCRIPTION
This PR uses the event collection's many-to-many (M2M) `event_tags` field to access related events by shared tags.