### PR TITLE
feat: generalize events filters

### DIFF
--- a/website-frontend/src/lib/components/filter/FilterBar.svelte
+++ b/website-frontend/src/lib/components/filter/FilterBar.svelte
@@ -6,13 +6,13 @@
 	import * as Tabs from '$lib/@shadcn-svelte/ui/tabs';
 	import { goto } from '$app/navigation';
 	import { page } from '$app/stores';
-	import { onMount } from 'svelte';
 
 	export let controls: FilterControls,
 		timed: boolean = false;
 
-	let filter: 'upcoming' | 'past' | 'all' = (() => {
-		const query: URLSearchParams = new URLSearchParams($page.url.searchParams.toString());
+	$: query = new URLSearchParams($page.url.searchParams.toString());
+
+	$: filter = (() => {
 		const time = query.get('time');
 		if (time === 'upcoming' || time === 'past' || time === 'all') {
 			return time;
@@ -21,7 +21,6 @@
 	})();
 
 	function time_nav(time: string): void {
-		const query = new URLSearchParams($page.url.searchParams.toString());
 		if (['all', 'past'].includes(time)) {
 			query.set('time', time);
 		} else {
@@ -29,10 +28,6 @@
 		}
 		goto(`?${query.toString()}`, { noScroll: true });
 	}
-
-	onMount(() => {
-		time_nav('upcoming');
-	});
 </script>
 
 <div
@@ -53,7 +48,7 @@
 		{/if}
 	</div>
 	{#if timed}
-		<Tabs.Root bind:value={filter}>
+		<Tabs.Root value={filter}>
 			<Tabs.List class="rounded-3xl bg-muted *:w-36 *:rounded-3xl">
 				<Tabs.Trigger on:click={() => time_nav('upcoming')} value="upcoming"
 					><span class="text-muted-foreground">Upcoming</span></Tabs.Trigger

--- a/website-frontend/src/lib/components/filter/FilterButton.svelte
+++ b/website-frontend/src/lib/components/filter/FilterButton.svelte
@@ -1,18 +1,18 @@
 <script lang="ts">
-	import type { FilterControl } from '$lib/types/filter_controls';
 	import { ChevronUp, ChevronDown } from 'lucide-svelte';
 	import * as DropdownMenu from '$lib/@shadcn-svelte/ui/dropdown-menu';
 	import { page } from '$app/stores';
 	import { goto } from '$app/navigation';
 
-	export let control: FilterControl;
+	export let control;
 	$: ({ name, categories } = control);
 
 	let hide = true;
 
-	function nav(name: string, value: string, checked: boolean): void {
-		const query = new URLSearchParams($page.url.searchParams.toString());
-		if (!checked) {
+	$: query = new URLSearchParams($page.url.searchParams.toString());
+
+	function nav(name: string, value: string): void {
+		if (!query.has(name, value)) {
 			query.append(name, value);
 		} else {
 			query.delete(name, value);
@@ -44,12 +44,12 @@
 	<DropdownMenu.Content>
 		{#if categories}
 			<DropdownMenu.Group>
-				{#each categories as { categoryName, checked }}
+				{#each categories as categoryName}
 					<DropdownMenu.CheckboxItem
-						bind:checked
+						checked={query.has(name, categoryName)}
 						onCheckedChange={() => {
-							nav(name, categoryName, checked);
-							hide = true;
+							nav(name, categoryName);
+							hide = !hide;
 						}}>{categoryName}</DropdownMenu.CheckboxItem
 					>
 				{/each}

--- a/website-frontend/src/lib/models-helpers.ts
+++ b/website-frontend/src/lib/models-helpers.ts
@@ -2,6 +2,3 @@ import sanitize from 'sanitize-html';
 import { transform } from 'valibot';
 
 export const cleanHtml = transform((input: string) => sanitize(input));
-export const toDateTime = transform((input: string) => {
-	return input as 'datetime';
-});

--- a/website-frontend/src/lib/models/event.ts
+++ b/website-frontend/src/lib/models/event.ts
@@ -22,7 +22,11 @@ const BaseEvent = object({
 	tags: nullable(array(string())),
 	start_date: pipe(string(), isoTimestamp(), toDateTime),
 	end_date: nullable(pipe(string(), isoTimestamp(), toDateTime)),
-	event_area: nullable(string()),
+	event_area: nullable(
+		object({
+			name: string()
+		})
+	),
 	display_location: nullable(string())
 });
 

--- a/website-frontend/src/lib/models/event.ts
+++ b/website-frontend/src/lib/models/event.ts
@@ -11,37 +11,12 @@ import {
 	pipe,
 	string,
 	union,
-	type GenericSchema,
 	type InferOutput
 } from 'valibot';
+import { EventsRelated } from './junctions/events_related';
+import { EventsArea } from './events_areas';
 
-export type Event = {
-	id: number;
-	slug: string;
-	date_created: string;
-	event_headline: string;
-	hero_image?: string | null;
-	event_content: string;
-	tags: string[] | null;
-	start_date: 'datetime';
-	end_date: 'datetime' | null;
-	event_area: {
-		name: string;
-	} | null;
-	display_location: string | null;
-	event_tags: {
-		events_tags_id: {
-			name: string;
-			related_events?:
-				| string[]
-				| {
-						events_id: Event;
-				  }[];
-		};
-	}[];
-};
-
-export const Event: GenericSchema<Event> = object({
+export const Event = object({
 	id: number(),
 	slug: string(),
 	date_created: pipe(string(), isoTimestamp()),
@@ -51,31 +26,12 @@ export const Event: GenericSchema<Event> = object({
 	tags: nullable(array(string())),
 	start_date: custom<'datetime'>((input) => typeof input === 'string'),
 	end_date: nullable(custom<'datetime'>((input) => typeof input === 'string')),
-	event_area: nullable(
-		object({
-			name: string()
-		})
-	),
+	event_area: union([string(), lazy(() => EventsArea)]),
 	display_location: nullable(string()),
-	event_tags: array(
-		object({
-			events_tags_id: object({
-				name: string(),
-				related_events: optional(
-					union([
-						array(string()),
-						array(
-							object({
-								events_id: lazy(() => Event)
-							})
-						)
-					])
-				)
-			})
-		})
-	)
+	event_tags: union([array(string()), lazy(() => EventsRelated)])
 });
 
 export const Events = array(Event);
 
+export type Event = InferOutput<typeof Event>;
 export type Events = InferOutput<typeof Events>;

--- a/website-frontend/src/lib/models/event.ts
+++ b/website-frontend/src/lib/models/event.ts
@@ -49,8 +49,8 @@ export const Event: GenericSchema<Event> = object({
 	hero_image: optional(nullable(string())),
 	event_content: pipe(string(), cleanHtml),
 	tags: nullable(array(string())),
-	start_date: custom<'datetime'>((input) => (typeof input === 'string' ? true : false)),
-	end_date: nullable(custom<'datetime'>((input) => (typeof input === 'string' ? true : false))),
+	start_date: custom<'datetime'>((input) => typeof input === 'string'),
+	end_date: nullable(custom<'datetime'>((input) => typeof input === 'string')),
 	event_area: nullable(
 		object({
 			name: string()

--- a/website-frontend/src/lib/models/event.ts
+++ b/website-frontend/src/lib/models/event.ts
@@ -1,6 +1,7 @@
-import { cleanHtml, toDateTime } from '$lib/models-helpers';
+import { cleanHtml } from '$lib/models-helpers';
 import {
 	array,
+	custom,
 	isoTimestamp,
 	lazy,
 	nullable,
@@ -22,8 +23,8 @@ export type Event = {
 	hero_image?: string | null;
 	event_content: string;
 	tags: string[] | null;
-	start_date: string;
-	end_date: string | null;
+	start_date: 'datetime';
+	end_date: 'datetime' | null;
 	event_area: {
 		name: string;
 	} | null;
@@ -48,8 +49,8 @@ export const Event: GenericSchema<Event> = object({
 	hero_image: optional(nullable(string())),
 	event_content: pipe(string(), cleanHtml),
 	tags: nullable(array(string())),
-	start_date: pipe(string(), isoTimestamp(), toDateTime),
-	end_date: nullable(pipe(string(), isoTimestamp(), toDateTime)),
+	start_date: custom<'datetime'>((input) => (typeof input === 'string' ? true : false)),
+	end_date: nullable(custom<'datetime'>((input) => (typeof input === 'string' ? true : false))),
 	event_area: nullable(
 		object({
 			name: string()

--- a/website-frontend/src/lib/models/event.ts
+++ b/website-frontend/src/lib/models/event.ts
@@ -1,18 +1,46 @@
 import { cleanHtml, toDateTime } from '$lib/models-helpers';
 import {
 	array,
-	intersect,
 	isoTimestamp,
+	lazy,
 	nullable,
 	number,
 	object,
 	optional,
 	pipe,
 	string,
+	union,
+	type GenericSchema,
 	type InferOutput
 } from 'valibot';
 
-const BaseEvent = object({
+export type Event = {
+	id: number;
+	slug: string;
+	date_created: string;
+	event_headline: string;
+	hero_image?: string | null;
+	event_content: string;
+	tags: string[] | null;
+	start_date: string;
+	end_date: string | null;
+	event_area: {
+		name: string;
+	} | null;
+	display_location: string | null;
+	event_tags: {
+		events_tags_id: {
+			name: string;
+			related_events?:
+				| string[]
+				| {
+						events_id: Event;
+				  }[];
+		};
+	}[];
+};
+
+export const Event: GenericSchema<Event> = object({
 	id: number(),
 	slug: string(),
 	date_created: pipe(string(), isoTimestamp()),
@@ -27,40 +55,26 @@ const BaseEvent = object({
 			name: string()
 		})
 	),
-	display_location: nullable(string())
-});
-
-const BaseEventTags = object({
-	event_tags: array(
-		object({
-			events_tags_id: object({
-				name: string()
-			})
-		})
-	)
-});
-
-const NestedEventTags = object({
+	display_location: nullable(string()),
 	event_tags: array(
 		object({
 			events_tags_id: object({
 				name: string(),
-				related_events: array(
-					object({
-						events_id: intersect([BaseEvent, BaseEventTags])
-					})
+				related_events: optional(
+					union([
+						array(string()),
+						array(
+							object({
+								events_id: lazy(() => Event)
+							})
+						)
+					])
 				)
 			})
 		})
 	)
 });
 
-export const Event = intersect([BaseEvent, BaseEventTags]);
 export const Events = array(Event);
-export const NestedEvent = intersect([BaseEvent, NestedEventTags]);
-export const NestedEvents = array(NestedEvent);
 
-export type Event = InferOutput<typeof Event>;
 export type Events = InferOutput<typeof Events>;
-export type NestedEvent = InferOutput<typeof NestedEvent>;
-export type NestedEvents = InferOutput<typeof NestedEvents>;

--- a/website-frontend/src/lib/models/events_areas.ts
+++ b/website-frontend/src/lib/models/events_areas.ts
@@ -1,11 +1,13 @@
-import { array, integer, number, object, pipe, string, type InferOutput } from 'valibot';
+import { array, integer, number, object, partial, pipe, string, type InferOutput } from 'valibot';
 
-export const EventsArea = object({
-	id: string(),
-	name: string(),
-	area: string(),
-	order: pipe(number(), integer())
-});
+export const EventsArea = partial(
+	object({
+		id: string(),
+		name: string(),
+		area: string(),
+		order: pipe(number(), integer())
+	})
+);
 
 export const EventsAreas = array(EventsArea);
 

--- a/website-frontend/src/lib/models/events_tags.ts
+++ b/website-frontend/src/lib/models/events_tags.ts
@@ -1,0 +1,16 @@
+import { array, lazy, object, optional, partial, string, union, type InferOutput } from 'valibot';
+import { EventsRelated } from './junctions/events_related';
+import { EventsTagsCategory } from './events_tags_categories';
+
+export const EventsTag = partial(
+	object({
+		name: string(),
+		tag_category: union([string(), lazy(() => EventsTagsCategory)]),
+		related_events: optional(union([array(string()), lazy(() => EventsRelated)]))
+	})
+);
+
+export const EventsTags = array(EventsTag);
+
+export type EventsTag = InferOutput<typeof EventsTag>;
+export type EventsTags = InferOutput<typeof EventsTags>;

--- a/website-frontend/src/lib/models/events_tags_categories.ts
+++ b/website-frontend/src/lib/models/events_tags_categories.ts
@@ -1,0 +1,11 @@
+import { array, nullable, object, string, type InferOutput } from 'valibot';
+
+export const EventsTagsCategory = object({
+	name: string(),
+	description: nullable(string())
+});
+
+export const EventsTagsCategories = array(EventsTagsCategory);
+
+export type EventsTagsCategory = InferOutput<typeof EventsTagsCategory>;
+export type EventsTagsCategories = InferOutput<typeof EventsTagsCategories>;

--- a/website-frontend/src/lib/models/junctions/events_related.ts
+++ b/website-frontend/src/lib/models/junctions/events_related.ts
@@ -1,0 +1,17 @@
+import { array, lazy, object, partial, string, union, type GenericSchema } from 'valibot';
+import { Event } from '../event';
+import { EventsTag } from '../events_tags';
+
+export type EventsRelated = {
+	events_id?: string | Event;
+	events_tags_id?: string | EventsTag;
+}[];
+
+export const EventsRelated: GenericSchema<EventsRelated> = array(
+	partial(
+		object({
+			events_id: union([string(), lazy(() => Event)]),
+			events_tags_id: union([string(), lazy(() => EventsTag)])
+		})
+	)
+);

--- a/website-frontend/src/lib/models/schema.ts
+++ b/website-frontend/src/lib/models/schema.ts
@@ -16,6 +16,9 @@ import { EventsAreas } from './events_areas';
 import { StudentsOrganizations } from './students_organizations';
 import { StudentsOrganizationsOverview } from './students_organizations_overview';
 import { Publications } from './publications';
+import { EventsTags } from './events_tags';
+import { EventsRelated } from './junctions/events_related';
+import { EventsTagsCategories } from './events_tags_categories';
 
 export const Schema = object({
 	global: Global,
@@ -32,6 +35,9 @@ export const Schema = object({
 	students_overview: StudentsOverview,
 	students_pages: StudentsPages,
 	events_areas: EventsAreas,
+	events_tags: EventsTags,
+	events_tags_categories: EventsTagsCategories,
+	events_related: EventsRelated,
 	students_organizations: StudentsOrganizations,
 	students_organizations_overview: StudentsOrganizationsOverview,
 	publications: Publications

--- a/website-frontend/src/routes/+page.server.ts
+++ b/website-frontend/src/routes/+page.server.ts
@@ -6,7 +6,7 @@ export async function load({ fetch }) {
 	const directus = getDirectusInstance(fetch);
 	const global = await directus.request(readSingleton('global'));
 	const events = await directus.request(
-		readItems('events', { fields: ['*', 'event_tags.events_tags_id.name'] })
+		readItems('events', { fields: ['*', 'event_area.name', 'event_tags.events_tags_id.name'] })
 	);
 
 	return { global, events };

--- a/website-frontend/src/routes/events/+page.server.ts
+++ b/website-frontend/src/routes/events/+page.server.ts
@@ -8,7 +8,7 @@ export async function load({ fetch, url }) {
 	const directus = getDirectusInstance(fetch);
 	const filters = {
 		locations: url.searchParams.getAll('location'),
-		discipline: url.searchParams.get('discipline'),
+		disciplines: url.searchParams.getAll('discipline'),
 		time: url.searchParams.get('time')
 	};
 	const locations = await directus
@@ -30,6 +30,15 @@ export async function load({ fetch, url }) {
 						filter: {
 							_and: [
 								{ event_area: { _in: locations } },
+								{
+									event_tags: {
+										events_tags_id: {
+											name: {
+												_in: filters.disciplines.length !== 0 ? filters.disciplines : undefined
+											}
+										}
+									}
+								},
 								{
 									_or: [
 										{
@@ -66,7 +75,20 @@ export async function load({ fetch, url }) {
 				await directus.request(
 					readItems('events', {
 						fields: ['*', 'event_tags.events_tags_id.name'],
-						filter: { event_area: { _in: locations } }
+						filter: {
+							_and: [
+								{ event_area: { _in: locations } },
+								{
+									event_tags: {
+										events_tags_id: {
+											name: {
+												_in: filters.disciplines.length !== 0 ? filters.disciplines : undefined
+											}
+										}
+									}
+								}
+							]
+						}
 					})
 				)
 			);
@@ -79,6 +101,15 @@ export async function load({ fetch, url }) {
 					filter: {
 						_and: [
 							{ event_area: { _in: locations } },
+							{
+								event_tags: {
+									events_tags_id: {
+										name: {
+											_in: filters.disciplines.length !== 0 ? filters.disciplines : undefined
+										}
+									}
+								}
+							},
 							{
 								start_date: {
 									_gte: '$NOW'

--- a/website-frontend/src/routes/events/+page.server.ts
+++ b/website-frontend/src/routes/events/+page.server.ts
@@ -11,25 +11,20 @@ export async function load({ fetch, url }) {
 		disciplines: url.searchParams.getAll('discipline'),
 		time: url.searchParams.get('time')
 	};
-	const locations = await directus
-		.request(
-			readItems('events_areas', {
-				filter: {
-					name: { _in: filters.locations.length !== 0 ? filters.locations : undefined }
-				}
-			})
-		)
-		.then((res) => res.map((res) => res.id));
 	const events = await (async () => {
 		if (filters.time === 'past') {
 			return parse(
 				Events,
 				await directus.request(
 					readItems('events', {
-						fields: ['*', 'event_tags.events_tags_id.name'],
+						fields: ['*', 'event_area.name', 'event_tags.events_tags_id.name'],
 						filter: {
 							_and: [
-								{ event_area: { _in: locations } },
+								{
+									event_area: {
+										name: { _in: filters.locations.length !== 0 ? filters.locations : undefined }
+									}
+								},
 								{
 									event_tags: {
 										events_tags_id: {
@@ -74,10 +69,14 @@ export async function load({ fetch, url }) {
 				Events,
 				await directus.request(
 					readItems('events', {
-						fields: ['*', 'event_tags.events_tags_id.name'],
+						fields: ['*', 'event_area.name', 'event_tags.events_tags_id.name'],
 						filter: {
 							_and: [
-								{ event_area: { _in: locations } },
+								{
+									event_area: {
+										name: { _in: filters.locations.length !== 0 ? filters.locations : undefined }
+									}
+								},
 								{
 									event_tags: {
 										events_tags_id: {
@@ -97,10 +96,14 @@ export async function load({ fetch, url }) {
 			Events,
 			await directus.request(
 				readItems('events', {
-					fields: ['*', 'event_tags.events_tags_id.name'],
+					fields: ['*', 'event_area.name', 'event_tags.events_tags_id.name'],
 					filter: {
 						_and: [
-							{ event_area: { _in: locations } },
+							{
+								event_area: {
+									name: { _in: filters.locations.length !== 0 ? filters.locations : undefined }
+								}
+							},
 							{
 								event_tags: {
 									events_tags_id: {

--- a/website-frontend/src/routes/events/+page.server.ts
+++ b/website-frontend/src/routes/events/+page.server.ts
@@ -11,6 +11,27 @@ export async function load({ fetch, url }) {
 		disciplines: url.searchParams.getAll('discipline'),
 		time: url.searchParams.get('time')
 	};
+	const location_filters = await directus
+		.request(
+			readItems('events_areas', {
+				fields: ['name']
+			})
+		)
+		.then((res) => res.map(({ name }) => name));
+	const discipline_filters = await directus
+		.request(
+			readItems('events_tags', {
+				fields: ['name'],
+				filter: {
+					tag_category: {
+						name: {
+							_eq: 'discipline'
+						}
+					}
+				}
+			})
+		)
+		.then((res) => res.map(({ name }) => name));
 	const events = await (async () => {
 		if (filters.time === 'past') {
 			return parse(
@@ -125,5 +146,5 @@ export async function load({ fetch, url }) {
 		);
 	})();
 
-	return { events };
+	return { events, location_filters, discipline_filters };
 }

--- a/website-frontend/src/routes/events/+page.svelte
+++ b/website-frontend/src/routes/events/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	/** @type {import('./$types').PageData} */
-	import type { FilterControls } from '$lib/types/filter_controls';
 	import Banner from '$lib/components/banner/Banner.svelte';
 	import * as Carousel from '$lib/@shadcn-svelte/ui/carousel/index';
 	import FeaturedEventCard from '$lib/components/events/FeaturedEventCard.svelte';
@@ -9,7 +8,7 @@
 
 	export let data;
 
-	$: ({ events } = data);
+	$: ({ events, location_filters, discipline_filters } = data);
 
 	$: featured = events?.slice(0, 3);
 
@@ -17,36 +16,14 @@
 	let shown = inc;
 	$: eventList = events?.slice(0, shown);
 
-	let controls: FilterControls = [
+	$: controls = [
 		{
 			name: 'location',
-			categories: [
-				{
-					categoryName: 'Department of Computer Science',
-					checked: false
-				},
-				{
-					categoryName: 'University of the Philippines Diliman',
-					checked: false
-				},
-				{
-					categoryName: 'Others',
-					checked: false
-				}
-			]
+			categories: location_filters
 		},
 		{
 			name: 'discipline',
-			categories: [
-				{
-					categoryName: 'artificial intelligence',
-					checked: false
-				},
-				{
-					categoryName: 'physics',
-					checked: false
-				}
-			]
+			categories: discipline_filters
 		}
 	];
 

--- a/website-frontend/src/routes/events/+page.svelte
+++ b/website-frontend/src/routes/events/+page.svelte
@@ -34,6 +34,19 @@
 					checked: false
 				}
 			]
+		},
+		{
+			name: 'discipline',
+			categories: [
+				{
+					categoryName: 'artificial intelligence',
+					checked: false
+				},
+				{
+					categoryName: 'physics',
+					checked: false
+				}
+			]
 		}
 	];
 

--- a/website-frontend/src/routes/events/+page.ts
+++ b/website-frontend/src/routes/events/+page.ts
@@ -1,6 +1,8 @@
 /** @type {import('./$types').PageLoad} */
 export async function load({ data }) {
 	return {
-		events: data.events
+		events: data.events,
+		location_filters: data.location_filters,
+		discipline_filters: data.discipline_filters
 	};
 }

--- a/website-frontend/src/routes/events/[slug]/+page.server.ts
+++ b/website-frontend/src/routes/events/[slug]/+page.server.ts
@@ -39,7 +39,7 @@ export async function load({ params, fetch }) {
 		.map((item) => {
 			if (typeof item === 'string') return [];
 			if (typeof item.events_tags_id === 'string') return [];
-			return item.events_tags_id.related_events ?? [];
+			return item.events_tags_id?.related_events ?? [];
 		})
 		.flat();
 
@@ -47,14 +47,21 @@ export async function load({ params, fetch }) {
 		if (event.event_tags.length != 0) {
 			return event_tags
 				.filter((item) => typeof item !== 'string')
-				.filter(
-					({ events_id }, index) =>
-						events_id.id != event.id &&
-						!event_tags
-							.filter((item) => typeof item !== 'string')
-							.map(({ events_id }) => events_id.id)
-							.includes(events_id.id, index + 1)
-				)
+				.filter(({ events_id }, index) => {
+					if (typeof events_id !== 'string') {
+						return (
+							events_id?.id != event.id &&
+							!event_tags
+								.filter((item) => typeof item !== 'string')
+								.map(({ events_id }) => {
+									if (typeof events_id !== 'string') {
+										return events_id?.id;
+									}
+								})
+								.includes(events_id?.id, index + 1)
+						);
+					}
+				})
 				.map((res) => res.events_id);
 		}
 		return [];

--- a/website-frontend/src/routes/events/[slug]/+page.server.ts
+++ b/website-frontend/src/routes/events/[slug]/+page.server.ts
@@ -37,6 +37,8 @@ export async function load({ params, fetch }) {
 	const event = events[0];
 	const event_tags = event.event_tags
 		.map((item) => {
+			if (typeof item === 'string') return [];
+			if (typeof item.events_tags_id === 'string') return [];
 			return item.events_tags_id.related_events ?? [];
 		})
 		.flat();

--- a/website-frontend/src/routes/events/[slug]/+page.server.ts
+++ b/website-frontend/src/routes/events/[slug]/+page.server.ts
@@ -15,8 +15,10 @@ export async function load({ params, fetch }) {
 			readItems('events', {
 				fields: [
 					'*',
+					'event_area.name',
 					'event_tags.events_tags_id.name',
 					'event_tags.events_tags_id.related_events.events_id.*',
+					'event_tags.events_tags_id.related_events.events_id.event_area.name',
 					'event_tags.events_tags_id.related_events.events_id.event_tags.events_tags_id.name'
 				],
 				filter: {


### PR DESCRIPTION
This PR adds filter by discipline category logic through the use of the discipline tag inside the `events_tags_categories` collection and generalizes filter options through dedicated fetches.