### PR TITLE
feat: add Publications

### DIFF
--- a/website-frontend/src/lib/components/nav/NavList.svelte
+++ b/website-frontend/src/lib/components/nav/NavList.svelte
@@ -13,6 +13,7 @@
 	<NavItem href="/about/citizens-charter" to="Citizen's Charter" />
 </NavItem>
 <NavItem href="/events" to="Events" />
+<NavItem href="/publications" to="Publications" />
 <NavItem href="/people" to="People" dropdown={true}>
 	<NavItem href="/people/regular-faculty" to="Regular Faculty" />
 	<NavItem

--- a/website-frontend/src/lib/models/publications.ts
+++ b/website-frontend/src/lib/models/publications.ts
@@ -1,0 +1,37 @@
+import { array, isoDate, nullable, object, pipe, string, type InferOutput } from 'valibot';
+
+const Author = object({
+	first_name: string(),
+	last_name: string()
+});
+
+const AccessLink = object({
+	url: string()
+});
+
+export const Publication = object({
+	id: string(),
+	title: string(),
+	publish_date: nullable(pipe(string(), isoDate())),
+	authors: array(Author),
+	abstract: string(),
+	laboratory: object({
+		id: string(),
+		name: string()
+	}),
+	hero_image: string(),
+	publication_tag: nullable(
+		object({
+			id: string(),
+			name: string()
+		})
+	),
+	access_links: nullable(array(AccessLink))
+});
+
+export const Publications = array(Publication);
+
+export type Author = InferOutput<typeof Author>;
+export type AccessLink = InferOutput<typeof AccessLink>;
+export type Publication = InferOutput<typeof Publication>;
+export type Publications = InferOutput<typeof Publications>;

--- a/website-frontend/src/lib/models/publications.ts
+++ b/website-frontend/src/lib/models/publications.ts
@@ -17,6 +17,7 @@ export const Publication = object({
 	abstract: string(),
 	laboratory: string(),
 	hero_image: string(),
+	publication_tag: nullable(array(string())),
 	access_links: nullable(array(AccessLink))
 });
 

--- a/website-frontend/src/lib/models/publications.ts
+++ b/website-frontend/src/lib/models/publications.ts
@@ -15,17 +15,8 @@ export const Publication = object({
 	publish_date: nullable(pipe(string(), isoDate())),
 	authors: array(Author),
 	abstract: string(),
-	laboratory: object({
-		id: string(),
-		name: string()
-	}),
+	laboratory: string(),
 	hero_image: string(),
-	publication_tag: nullable(
-		object({
-			id: string(),
-			name: string()
-		})
-	),
 	access_links: nullable(array(AccessLink))
 });
 

--- a/website-frontend/src/lib/models/schema.ts
+++ b/website-frontend/src/lib/models/schema.ts
@@ -15,6 +15,7 @@ import { StudentsPages } from './students_pages';
 import { EventsAreas } from './events_areas';
 import { StudentsOrganizations } from './students_organizations';
 import { StudentsOrganizationsOverview } from './students_organizations_overview';
+import { Publications } from './publications';
 
 export const Schema = object({
 	global: Global,
@@ -32,7 +33,8 @@ export const Schema = object({
 	students_pages: StudentsPages,
 	events_areas: EventsAreas,
 	students_organizations: StudentsOrganizations,
-	students_organizations_overview: StudentsOrganizationsOverview
+	students_organizations_overview: StudentsOrganizationsOverview,
+	publications: Publications
 });
 
 export type Schema = InferOutput<typeof Schema>;

--- a/website-frontend/src/routes/publications/+page.server.ts
+++ b/website-frontend/src/routes/publications/+page.server.ts
@@ -7,7 +7,7 @@ export async function load({ fetch }) {
 	return {
 		publications: await directus.request(
 			readItems('publications', {
-				sort: '-publish_date',
+				sort: '-publish_date'
 			})
 		)
 	};

--- a/website-frontend/src/routes/publications/+page.server.ts
+++ b/website-frontend/src/routes/publications/+page.server.ts
@@ -1,14 +1,21 @@
 /** @type {import('./$types').PageServerLoad} */
 import { readItems } from '@directus/sdk';
+import { parse } from 'valibot';
+import { Publications } from '$lib/models/publications';
 import getDirectusInstance from '$lib/directus';
 
 export async function load({ fetch }) {
 	const directus = getDirectusInstance(fetch);
-	return {
-		publications: await directus.request(
+	const publications = parse(
+		Publications,
+		await directus.request(
 			readItems('publications', {
 				sort: '-publish_date'
 			})
 		)
+	);
+
+	return {
+		publications
 	};
 }

--- a/website-frontend/src/routes/publications/+page.server.ts
+++ b/website-frontend/src/routes/publications/+page.server.ts
@@ -1,0 +1,12 @@
+/** @type {import('./$types').PageServerLoad} */
+import { readItems } from '@directus/sdk';
+import { parse } from 'valibot';
+import { Publications } from '$lib/models/publications';
+import getDirectusInstance from '$lib/directus';
+
+export async function load({ fetch }) {
+	const directus = getDirectusInstance(fetch);
+	return {
+		publications: parse(Publications, await directus.request(readItems('publications')))
+	};
+}

--- a/website-frontend/src/routes/publications/+page.server.ts
+++ b/website-frontend/src/routes/publications/+page.server.ts
@@ -1,12 +1,14 @@
 /** @type {import('./$types').PageServerLoad} */
 import { readItems } from '@directus/sdk';
-import { parse } from 'valibot';
-import { Publications } from '$lib/models/publications';
 import getDirectusInstance from '$lib/directus';
 
 export async function load({ fetch }) {
 	const directus = getDirectusInstance(fetch);
 	return {
-		publications: parse(Publications, await directus.request(readItems('publications')))
+		publications: await directus.request(
+			readItems('publications', {
+				sort: '-publish_date',
+			})
+		)
 	};
 }

--- a/website-frontend/src/routes/publications/+page.svelte
+++ b/website-frontend/src/routes/publications/+page.svelte
@@ -9,12 +9,40 @@
 
 	const inc = 12;
 	let shown = inc;
-	$: publicationsList = publications?.slice(0, shown);
+
+	let sortMethod: 'date' | 'author' = 'date';
+
+	$: sortedPublications = [...publications].sort((a, b) => {
+		if (sortMethod === 'author') {
+			const aLastName = a.authors[0]?.last_name || '';
+			const bLastName = b.authors[0]?.last_name || '';
+			return aLastName.localeCompare(bLastName);
+		} else {
+			return (b.publish_date ?? '1970-01-01').localeCompare(a.publish_date ?? '1970-01-01');
+		}
+	});
+
+	$: publicationsList = sortedPublications?.slice(0, shown);
 </script>
 
 <body>
 	<div class="relative z-0">
 		<Banner title="Publications" />
+	</div>
+
+	<div class="mx-auto my-4 flex justify-center gap-4">
+		<button
+			class="rounded px-4 py-2 {sortMethod === 'date' ? 'bg-blue-600 text-white' : 'bg-gray-200'}"
+			on:click={() => (sortMethod = 'date')}
+		>
+			Sort by Date
+		</button>
+		<button
+			class="rounded px-4 py-2 {sortMethod === 'author' ? 'bg-blue-600 text-white' : 'bg-gray-200'}"
+			on:click={() => (sortMethod = 'author')}
+		>
+			Sort by Author
+		</button>
 	</div>
 
 	<div

--- a/website-frontend/src/routes/publications/+page.svelte
+++ b/website-frontend/src/routes/publications/+page.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+	/** @type {import('./$types').PageData} */
+	import Banner from '$lib/components/banner/Banner.svelte';
+	import LoadMore from '$lib/components/load_more/LoadMore.svelte';
+	import { PUBLIC_APIURL } from '$env/static/public';
+
+	export let data;
+	const { publications } = data;
+
+	const inc = 12;
+	let shown = inc;
+	$: publicationsList = publications?.slice(0, shown);
+</script>
+
+<body>
+	<div class="relative z-0">
+		<Banner title="Publications" />
+	</div>
+
+	<div
+		class="mx-auto my-3 grid
+        max-w-[94vw] grid-cols-2 gap-2 pb-20
+        md:my-8 md:max-w-[80vw] md:grid-cols-4 md:gap-4"
+	>
+		{#each publicationsList as publication}
+			<a href="/publications/{publication.id}">
+				<img
+					src="{PUBLIC_APIURL}/assets/{publication.hero_image}"
+					alt={publication.title}
+					class="h-48 w-full object-cover rounded-lg"
+				/>
+				<p>{publication.title}</p>
+				{#each publication.authors as author}
+					<p>{author.last_name}, {author.first_name}</p>
+				{/each}
+			</a>
+		{/each}
+	</div>
+	{#if shown < publications.length}
+		<div class="flex items-center justify-center">
+			<LoadMore {inc} bind:shown />
+		</div>
+	{/if}
+</body>

--- a/website-frontend/src/routes/publications/+page.svelte
+++ b/website-frontend/src/routes/publications/+page.svelte
@@ -27,9 +27,10 @@
 				<img
 					src="{PUBLIC_APIURL}/assets/{publication.hero_image}"
 					alt={publication.title}
-					class="h-48 w-full object-cover rounded-lg"
+					class="h-48 w-full rounded-lg object-cover"
 				/>
 				<p>{publication.title}</p>
+				<p>{publication.publication_tag}</p>
 				{#each publication.authors as author}
 					<p>{author.last_name}, {author.first_name}</p>
 				{/each}


### PR DESCRIPTION
This pull request introduces a new feature to the website frontend, adding a "Publications" section.

* Added a new navigation item for "Publications".
* Created a new data model for publications, including types for `Author`, `AccessLink`, and `Publication`.
* Integrated the new `Publications` model into the existing schema.
* Implemented server-side code to fetch publications from the Directus CMS, sorted by publish date.

This does not yet implement sorting. Errors with schema validation disallow the use of nested fields. Also, since the `authors` field is in json format and not a string, it could not be sorted natively using directus commands. Will commit changes later on to transform the data instead.