### PR TITLE
feat: add sort to event filter fields

### DIFF
--- a/website-frontend/src/routes/events/+page.server.ts
+++ b/website-frontend/src/routes/events/+page.server.ts
@@ -14,7 +14,8 @@ export async function load({ fetch, url }) {
 	const location_filters = await directus
 		.request(
 			readItems('events_areas', {
-				fields: ['name']
+				fields: ['name'],
+				sort: ['order']
 			})
 		)
 		.then((res) => res.map(({ name }) => name));
@@ -28,7 +29,8 @@ export async function load({ fetch, url }) {
 							_eq: 'discipline'
 						}
 					}
-				}
+				},
+				sort: ['name']
 			})
 		)
 		.then((res) => res.map(({ name }) => name));


### PR DESCRIPTION
This PR orders event filter fields based on their specifications. Specifically, location filters are sorted by their `order` field, while discipline filters are sorted alphabetically.