### PR TITLE
fix: set correct nav links for fetched academics programs

### DIFF
--- a/website-frontend/src/routes/academics/+page.svelte
+++ b/website-frontend/src/routes/academics/+page.svelte
@@ -24,7 +24,9 @@
 			List of programs offered by the department
 		</h1>
 		{#each academics_programs as program}
-			<ul><a href="{program.category.slug}/{program.slug}">{program.title}</a></ul>
+			<ul>
+				<a href="academics/{program.category.slug}/programs/{program.slug}">{program.title}</a>
+			</ul>
 		{/each}
 		<br />
 

--- a/website-frontend/src/routes/academics/[category]/+page.svelte
+++ b/website-frontend/src/routes/academics/[category]/+page.svelte
@@ -24,7 +24,9 @@
 			{academics_category.name} programs offered by the department
 		</h1>
 		{#each academics_programs as program}
-			<ul><a href="{program.category.slug}/{program.slug}">{program.title}</a></ul>
+			<ul>
+				<a href="academics/{program.category.slug}/programs/{program.slug}">{program.title}</a>
+			</ul>
 		{/each}
 		<br />
 


### PR DESCRIPTION
This PR fixes nav links for fetched academics programs in academics overview page and academics programs subpages.

Requires:
- #89 