### PR TITLE
fix: solve existing code quality check errors

### DIFF
--- a/website-frontend/package.json
+++ b/website-frontend/package.json
@@ -16,6 +16,7 @@
 		"test": "pnpm exec playwright test"
 	},
 	"devDependencies": {
+		"@eslint/js": "^9.21.0",
 		"@playwright/test": "^1.50.1",
 		"@skeletonlabs/skeleton": "2.10.2",
 		"@skeletonlabs/tw-plugin": "0.4.0",

--- a/website-frontend/pnpm-lock.yaml
+++ b/website-frontend/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
         specifier: ^0.42.1
         version: 0.42.1(typescript@5.7.3)
     devDependencies:
+      '@eslint/js':
+        specifier: ^9.21.0
+        version: 9.21.0
       '@playwright/test':
         specifier: ^1.50.1
         version: 1.50.1
@@ -312,6 +315,10 @@ packages:
 
   '@eslint/js@9.20.0':
     resolution: {integrity: sha512-iZA07H9io9Wn836aVTytRaNqh00Sad+EamwOVJT12GTLw1VGMFV/4JaME+JjLtr9fiGaoWgYnS54wrfWsSs4oQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/js@9.21.0':
+    resolution: {integrity: sha512-BqStZ3HX8Yz6LvsF5ByXYrtigrV5AXADWLAGc7PH/1SxOb7/FIYYMszZZWiUou/GB9P2lXWk2SV4d+Z8h0nknw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/object-schema@2.1.5':
@@ -1878,6 +1885,8 @@ snapshots:
       - supports-color
 
   '@eslint/js@9.20.0': {}
+
+  '@eslint/js@9.21.0': {}
 
   '@eslint/object-schema@2.1.5': {}
 

--- a/website-frontend/src/lib/components/carousels/LabHero.svelte
+++ b/website-frontend/src/lib/components/carousels/LabHero.svelte
@@ -87,7 +87,7 @@
 				class="flex flex-col items-center justify-center text-center lg:flex-row lg:justify-between"
 			>
 				<div class="my-5 flex gap-2 lg:mb-0 lg:mt-5">
-					{#each Array(count) as _, index}
+					{#each Array(count).keys() as index}
 						<button
 							class="duration-400 h-2 w-2 rounded-full transition-all
 							{index === current - 1 ? 'bg-primary-foreground' : 'bg-gray-400'}"

--- a/website-frontend/src/lib/components/events/FeaturedEventCard.svelte
+++ b/website-frontend/src/lib/components/events/FeaturedEventCard.svelte
@@ -41,7 +41,9 @@
 			{#if event.event_tags}
 				<div class="py-1 text-xs font-bold text-gray-600">
 					{#each event.event_tags as tag, index}
-						<p>{tag.events_tags_id.name}{index < event.event_tags.length - 1 ? ',' : ''}</p>
+						{#if typeof tag !== 'string' && typeof tag.events_tags_id !== 'string'}
+							<p>{tag.events_tags_id.name}{index < event.event_tags.length - 1 ? ',' : ''}</p>
+						{/if}
 					{/each}
 				</div>
 			{/if}

--- a/website-frontend/src/lib/components/flexible_content/FlexibleContent.svelte
+++ b/website-frontend/src/lib/components/flexible_content/FlexibleContent.svelte
@@ -2,16 +2,15 @@
 	import { onMount } from 'svelte';
 	import { enhanceWysiwygContent } from '.';
 	export let content: string = '';
-	export let isDark: boolean = false;
 
 	let enhancedContent = content;
 
 	onMount(() => {
-		enhancedContent = content ? enhanceWysiwygContent(content, isDark) : '';
+		enhancedContent = content ? enhanceWysiwygContent(content) : '';
 	});
 
 	$: if (typeof window !== 'undefined') {
-		enhancedContent = content ? enhanceWysiwygContent(content, isDark) : '';
+		enhancedContent = content ? enhanceWysiwygContent(content) : '';
 	}
 </script>
 

--- a/website-frontend/src/lib/components/flexible_content/index.ts
+++ b/website-frontend/src/lib/components/flexible_content/index.ts
@@ -11,7 +11,7 @@ const elementClassMap = {
 	hr: 'my-4'
 };
 
-export function enhanceWysiwygContent(htmlContent: string, isDark: boolean = false): string {
+export function enhanceWysiwygContent(htmlContent: string): string {
 	if (typeof window === 'undefined') {
 		return htmlContent;
 	}

--- a/website-frontend/src/lib/components/flexible_content/index.ts
+++ b/website-frontend/src/lib/components/flexible_content/index.ts
@@ -11,6 +11,7 @@ const elementClassMap = {
 	hr: 'my-4'
 };
 
+// TODO: Add dark mode implementation
 export function enhanceWysiwygContent(htmlContent: string): string {
 	if (typeof window === 'undefined') {
 		return htmlContent;

--- a/website-frontend/src/lib/components/table/DataTable.svelte
+++ b/website-frontend/src/lib/components/table/DataTable.svelte
@@ -2,7 +2,7 @@
 	import * as Table from '$lib/@shadcn-svelte/ui/table';
 	import { deslugify } from '$lib/utils';
 
-	export let data: Array<Object>;
+	export let data: Array<object>;
 </script>
 
 {#if data.length !== 0}

--- a/website-frontend/src/lib/models/academics_categories.ts
+++ b/website-frontend/src/lib/models/academics_categories.ts
@@ -1,14 +1,12 @@
 import { cleanHtml } from '$lib/models-helpers';
-import { array, nullable, object, partial, pipe, string, type InferOutput } from 'valibot';
+import { array, nullable, object, pipe, string, type InferOutput } from 'valibot';
 
-export const AcademicsCategory = partial(
-	object({
-		name: string(),
-		slug: string(),
-		description: nullable(string()),
-		flexible_content: pipe(string(), cleanHtml)
-	})
-);
+export const AcademicsCategory = object({
+	name: string(),
+	slug: string(),
+	description: nullable(string()),
+	flexible_content: pipe(string(), cleanHtml)
+});
 
 export const AcademicsCategories = array(AcademicsCategory);
 

--- a/website-frontend/src/lib/models/academics_courses.ts
+++ b/website-frontend/src/lib/models/academics_courses.ts
@@ -5,7 +5,6 @@ import {
 	nullable,
 	number,
 	object,
-	partial,
 	pipe,
 	string,
 	union,
@@ -13,15 +12,13 @@ import {
 } from 'valibot';
 import { AcademicsProgramsCourses } from './junctions/academics_programs_courses';
 
-export const AcademicsCourse = partial(
-	object({
-		course_code: string(),
-		course_title: string(),
-		course_units: pipe(number(), integer()),
-		course_description: nullable(string()),
-		related_academics_programs: union([array(number()), lazy(() => AcademicsProgramsCourses)])
-	})
-);
+export const AcademicsCourse = object({
+	course_code: string(),
+	course_title: string(),
+	course_units: pipe(number(), integer()),
+	course_description: nullable(string()),
+	related_academics_programs: union([array(number()), lazy(() => AcademicsProgramsCourses)])
+});
 
 export const AcademicsCourses = array(AcademicsCourse);
 

--- a/website-frontend/src/lib/models/academics_programs.ts
+++ b/website-frontend/src/lib/models/academics_programs.ts
@@ -1,27 +1,15 @@
-import {
-	array,
-	lazy,
-	number,
-	object,
-	partial,
-	pipe,
-	string,
-	union,
-	type InferOutput
-} from 'valibot';
+import { array, lazy, number, object, pipe, string, union, type InferOutput } from 'valibot';
 import { AcademicsCategory } from './academics_categories';
 import { cleanHtml } from '$lib/models-helpers';
 import { AcademicsProgramsCourses } from './junctions/academics_programs_courses';
 
-export const AcademicsProgram = partial(
-	object({
-		title: string(),
-		slug: string(),
-		category: union([string(), lazy(() => AcademicsCategory)]),
-		flexible_content: pipe(string(), cleanHtml),
-		curriculum_table: union([array(number()), lazy(() => AcademicsProgramsCourses)])
-	})
-);
+export const AcademicsProgram = object({
+	title: string(),
+	slug: string(),
+	category: union([string(), lazy(() => AcademicsCategory)]),
+	flexible_content: pipe(string(), cleanHtml),
+	curriculum_table: union([array(number()), lazy(() => AcademicsProgramsCourses)])
+});
 
 export const AcademicsPrograms = array(AcademicsProgram);
 

--- a/website-frontend/src/lib/models/directus_files.ts
+++ b/website-frontend/src/lib/models/directus_files.ts
@@ -1,0 +1,10 @@
+import { array, object, string, type InferOutput } from 'valibot';
+
+export const DirectusFile = object({
+	id: string()
+});
+
+export const DirectusFiles = array(DirectusFile);
+
+export type DirectusFile = InferOutput<typeof DirectusFile>;
+export type DirectusFiles = InferOutput<typeof DirectusFiles>;

--- a/website-frontend/src/lib/models/events_areas.ts
+++ b/website-frontend/src/lib/models/events_areas.ts
@@ -1,13 +1,11 @@
-import { array, integer, number, object, partial, pipe, string, type InferOutput } from 'valibot';
+import { array, integer, number, object, pipe, string, type InferOutput } from 'valibot';
 
-export const EventsArea = partial(
-	object({
-		id: string(),
-		name: string(),
-		area: string(),
-		order: pipe(number(), integer())
-	})
-);
+export const EventsArea = object({
+	id: string(),
+	name: string(),
+	area: string(),
+	order: pipe(number(), integer())
+});
 
 export const EventsAreas = array(EventsArea);
 

--- a/website-frontend/src/lib/models/events_tags.ts
+++ b/website-frontend/src/lib/models/events_tags.ts
@@ -1,14 +1,12 @@
-import { array, lazy, object, optional, partial, string, union, type InferOutput } from 'valibot';
+import { array, lazy, object, optional, string, union, type InferOutput } from 'valibot';
 import { EventsRelated } from './junctions/events_related';
 import { EventsTagsCategory } from './events_tags_categories';
 
-export const EventsTag = partial(
-	object({
-		name: string(),
-		tag_category: union([string(), lazy(() => EventsTagsCategory)]),
-		related_events: optional(union([array(string()), lazy(() => EventsRelated)]))
-	})
-);
+export const EventsTag = object({
+	name: string(),
+	tag_category: union([string(), lazy(() => EventsTagsCategory)]),
+	related_events: optional(union([array(string()), lazy(() => EventsRelated)]))
+});
 
 export const EventsTags = array(EventsTag);
 

--- a/website-frontend/src/lib/models/junctions/academics_programs_courses.ts
+++ b/website-frontend/src/lib/models/junctions/academics_programs_courses.ts
@@ -4,7 +4,6 @@ import {
 	lazy,
 	number,
 	object,
-	partial,
 	pipe,
 	string,
 	union,
@@ -14,19 +13,17 @@ import { AcademicsProgram } from '../academics_programs';
 import { AcademicsCourse } from '../academics_courses';
 
 export type AcademicsProgramsCourses = {
-	year?: number;
-	semester?: string;
-	academics_programs_id?: string | AcademicsProgram;
-	academics_courses_course_code?: string | AcademicsCourse;
+	year: number;
+	semester: string;
+	academics_programs_id: string | AcademicsProgram;
+	academics_courses_course_code: string | AcademicsCourse;
 }[];
 
 export const AcademicsProgramsCourses: GenericSchema<AcademicsProgramsCourses> = array(
-	partial(
-		object({
-			year: pipe(number(), integer()),
-			semester: string(),
-			academics_programs_id: union([string(), lazy(() => AcademicsProgram)]),
-			academics_courses_course_code: union([string(), lazy(() => AcademicsCourse)])
-		})
-	)
+	object({
+		year: pipe(number(), integer()),
+		semester: string(),
+		academics_programs_id: union([string(), lazy(() => AcademicsProgram)]),
+		academics_courses_course_code: union([string(), lazy(() => AcademicsCourse)])
+	})
 );

--- a/website-frontend/src/lib/models/junctions/events_related.ts
+++ b/website-frontend/src/lib/models/junctions/events_related.ts
@@ -1,17 +1,15 @@
-import { array, lazy, object, partial, string, union, type GenericSchema } from 'valibot';
+import { array, lazy, object, string, union, type GenericSchema } from 'valibot';
 import { Event } from '../event';
 import { EventsTag } from '../events_tags';
 
 export type EventsRelated = {
-	events_id?: string | Event;
-	events_tags_id?: string | EventsTag;
+	events_id: string | Event;
+	events_tags_id: string | EventsTag;
 }[];
 
 export const EventsRelated: GenericSchema<EventsRelated> = array(
-	partial(
-		object({
-			events_id: union([string(), lazy(() => Event)]),
-			events_tags_id: union([string(), lazy(() => EventsTag)])
-		})
-	)
+	object({
+		events_id: union([string(), lazy(() => Event)]),
+		events_tags_id: union([string(), lazy(() => EventsTag)])
+	})
 );

--- a/website-frontend/src/lib/models/junctions/laboratories_directus_files.ts
+++ b/website-frontend/src/lib/models/junctions/laboratories_directus_files.ts
@@ -1,0 +1,15 @@
+import { array, lazy, object, string, union, type GenericSchema } from 'valibot';
+import { Laboratory } from '../laboratories';
+import { DirectusFile } from '../directus_files';
+
+export type LaboratoriesDirectusFiles = {
+	laboratories_id: string | Laboratory;
+	directus_files_id: string | DirectusFile;
+}[];
+
+export const LaboratoriesDirectusFiles: GenericSchema<LaboratoriesDirectusFiles> = array(
+	object({
+		laboratories_id: union([string(), lazy(() => Laboratory)]),
+		directus_files_id: union([string(), lazy(() => DirectusFile)])
+	})
+);

--- a/website-frontend/src/lib/models/junctions/students_organizations_directus_files.ts
+++ b/website-frontend/src/lib/models/junctions/students_organizations_directus_files.ts
@@ -1,0 +1,16 @@
+import { array, lazy, object, string, union, type GenericSchema } from 'valibot';
+import { StudentsOrganization } from '../students_organizations';
+import { DirectusFile } from '../directus_files';
+
+export type StudentsOrganizationsDirectusFiles = {
+	laboratories_id: string | StudentsOrganization;
+	directus_files_id: string | DirectusFile;
+}[];
+
+export const StudentsOrganizationsDirectusFiles: GenericSchema<StudentsOrganizationsDirectusFiles> =
+	array(
+		object({
+			laboratories_id: union([string(), lazy(() => StudentsOrganization)]),
+			directus_files_id: union([string(), lazy(() => DirectusFile)])
+		})
+	);

--- a/website-frontend/src/lib/models/laboratories.ts
+++ b/website-frontend/src/lib/models/laboratories.ts
@@ -1,4 +1,5 @@
-import { array, nullable, object, string, type InferOutput } from 'valibot';
+import { array, lazy, nullable, object, string, union, type InferOutput } from 'valibot';
+import { LaboratoriesDirectusFiles } from './junctions/laboratories_directus_files';
 
 export const Laboratory = object({
 	id: string(),
@@ -7,7 +8,8 @@ export const Laboratory = object({
 	description: nullable(string()),
 	logo: nullable(string()),
 	location: nullable(string()),
-	contact_email: nullable(string())
+	contact_email: nullable(string()),
+	background_images: union([array(string()), lazy(() => LaboratoriesDirectusFiles)])
 });
 
 export const Laboratories = array(Laboratory);

--- a/website-frontend/src/lib/models/news.ts
+++ b/website-frontend/src/lib/models/news.ts
@@ -1,12 +1,21 @@
 import { cleanHtml } from '$lib/models-helpers';
-import { array, isoTimestamp, object, pick, pipe, string, type InferOutput } from 'valibot';
+import {
+	array,
+	isoTimestamp,
+	lazy,
+	object,
+	pipe,
+	required,
+	string,
+	type InferOutput
+} from 'valibot';
 import { DirectusUser } from './directus_users';
 
 export const NewsItem = object({
 	id: string(),
 	slug: string(),
-	user_created: pick(DirectusUser, ['first_name', 'last_name']),
-	user_updated: pick(DirectusUser, ['first_name', 'last_name']),
+	user_created: lazy(() => required(DirectusUser, ['first_name', 'last_name'])),
+	user_updated: lazy(() => required(DirectusUser, ['first_name', 'last_name'])),
 	date_created: pipe(string(), isoTimestamp()),
 	date_updated: pipe(string(), isoTimestamp()),
 	title: string(),

--- a/website-frontend/src/lib/models/schema.ts
+++ b/website-frontend/src/lib/models/schema.ts
@@ -9,6 +9,7 @@ import { PeopleOverview } from './people_overview';
 import { PeopleCategories } from './people_categories';
 import { PeopleLaboratories } from './people_laboratories';
 import { Laboratories } from './laboratories';
+import { LaboratoriesDirectusFiles } from './junctions/laboratories_directus_files';
 import { About } from './about';
 import { AboutPages } from './about_pages';
 import { StudentsOverview } from './students_overview';
@@ -16,6 +17,7 @@ import { StudentsPages } from './students_pages';
 import { EventsAreas } from './events_areas';
 import { StudentsOrganizations } from './students_organizations';
 import { StudentsOrganizationsOverview } from './students_organizations_overview';
+import { StudentsOrganizationsDirectusFiles } from './junctions/students_organizations_directus_files';
 import { Publications } from './publications';
 import { EventsTags } from './events_tags';
 import { EventsRelated } from './junctions/events_related';
@@ -27,6 +29,7 @@ import { AcademicsCourses } from './academics_courses';
 import { AcademicsPages } from './academics_pages';
 import { AcademicsProgramsCourses } from './junctions/academics_programs_courses';
 import { DirectusUsers } from './directus_users';
+import { DirectusFiles } from './directus_files';
 
 export const Schema = object({
 	global: Global,
@@ -39,6 +42,7 @@ export const Schema = object({
 	people_categories: PeopleCategories,
 	people_laboratories: PeopleLaboratories,
 	laboratories: Laboratories,
+	laboratories_directus_files: LaboratoriesDirectusFiles,
 	about: About,
 	about_pages: AboutPages,
 	students_overview: StudentsOverview,
@@ -49,6 +53,7 @@ export const Schema = object({
 	events_related: EventsRelated,
 	students_organizations: StudentsOrganizations,
 	students_organizations_overview: StudentsOrganizationsOverview,
+	students_organizations_directus_files: StudentsOrganizationsDirectusFiles,
 	publications: Publications,
 	academics: Academics,
 	academics_categories: AcademicsCategories,
@@ -56,7 +61,8 @@ export const Schema = object({
 	academics_courses: AcademicsCourses,
 	academics_pages: AcademicsPages,
 	academics_programs_courses: AcademicsProgramsCourses,
-	directus_users: DirectusUsers
+	directus_users: DirectusUsers,
+	directus_files: DirectusFiles
 });
 
 export type Schema = InferOutput<typeof Schema>;

--- a/website-frontend/src/lib/models/students_organizations.ts
+++ b/website-frontend/src/lib/models/students_organizations.ts
@@ -1,5 +1,16 @@
 import { cleanHtml } from '$lib/models-helpers';
-import { array, object, string, nullable, type InferOutput, pipe, isoDate } from 'valibot';
+import {
+	array,
+	object,
+	string,
+	nullable,
+	type InferOutput,
+	pipe,
+	isoDate,
+	union,
+	lazy
+} from 'valibot';
+import { StudentsOrganizationsDirectusFiles } from './junctions/students_organizations_directus_files';
 
 export const StudentsOrganization = object({
 	name: string(),
@@ -11,7 +22,8 @@ export const StudentsOrganization = object({
 	logo: nullable(string()),
 	website: nullable(string()),
 	location: nullable(string()),
-	flexible_content: pipe(string(), cleanHtml)
+	flexible_content: pipe(string(), cleanHtml),
+	background_images: union([array(string()), lazy(() => StudentsOrganizationsDirectusFiles)])
 });
 
 export const StudentsOrganizations = array(StudentsOrganization);

--- a/website-frontend/src/routes/+page.server.ts
+++ b/website-frontend/src/routes/+page.server.ts
@@ -9,10 +9,12 @@ export async function load({ fetch }) {
 		readItems('news', {
 			fields: [
 				'*',
-				'user_created.first_name',
-				'user_created.last_name',
-				'user_updated.first_name',
-				'user_updated.last_name'
+				{
+					user_created: ['first_name', 'last_name']
+				},
+				{
+					user_updated: ['first_name', 'last_name']
+				}
 			],
 			sort: ['-date_created']
 		})

--- a/website-frontend/src/routes/+page.server.ts
+++ b/website-frontend/src/routes/+page.server.ts
@@ -18,7 +18,21 @@ export async function load({ fetch }) {
 		})
 	);
 	const events = await directus.request(
-		readItems('events', { fields: ['*', 'event_area.name', 'event_tags.events_tags_id.name'] })
+		readItems('events', {
+			fields: [
+				'*',
+				{
+					event_area: ['name']
+				},
+				{
+					event_tags: [
+						{
+							events_tags_id: ['name']
+						}
+					]
+				}
+			]
+		})
 	);
 
 	return { global, news, events };

--- a/website-frontend/src/routes/about/+page.server.ts
+++ b/website-frontend/src/routes/about/+page.server.ts
@@ -1,12 +1,10 @@
 /** @type {import('./$types').PageServerLoad} */
 import { readSingleton } from '@directus/sdk';
-import { parse } from 'valibot';
-import { About } from '$lib/models/about';
 import getDirectusInstance from '$lib/directus';
 
 export async function load({ fetch }) {
 	const directus = getDirectusInstance(fetch);
-	return {
-		about: parse(About, await directus.request(readSingleton('about')))
-	};
+	const about = await directus.request(readSingleton('about'));
+
+	return { about };
 }

--- a/website-frontend/src/routes/academics/+page.server.ts
+++ b/website-frontend/src/routes/academics/+page.server.ts
@@ -13,7 +13,12 @@ export async function load({ fetch }) {
 		AcademicsPrograms,
 		await directus.request(
 			readItems('academics_programs', {
-				fields: ['*', 'category.name', 'category.slug'],
+				fields: [
+					'*',
+					{
+						category: ['name', 'slug']
+					}
+				],
 				sort: ['title']
 			})
 		)

--- a/website-frontend/src/routes/academics/+page.server.ts
+++ b/website-frontend/src/routes/academics/+page.server.ts
@@ -1,35 +1,25 @@
 /** @type {import('./$types').PageServerLoad} */
 import getDirectusInstance from '$lib/directus';
-import { Academics } from '$lib/models/academics';
-import { AcademicsCourses } from '$lib/models/academics_courses';
-import { AcademicsPrograms } from '$lib/models/academics_programs';
 import { readItems, readSingleton } from '@directus/sdk';
-import { parse } from 'valibot';
 
 export async function load({ fetch }) {
 	const directus = getDirectusInstance(fetch);
-	const academics = parse(Academics, await directus.request(readSingleton('academics')));
-	const academics_programs = parse(
-		AcademicsPrograms,
-		await directus.request(
-			readItems('academics_programs', {
-				fields: [
-					'*',
-					{
-						category: ['name', 'slug']
-					}
-				],
-				sort: ['title']
-			})
-		)
+	const academics = await directus.request(readSingleton('academics'));
+	const academics_programs = await directus.request(
+		readItems('academics_programs', {
+			fields: [
+				'*',
+				{
+					category: ['name', 'slug']
+				}
+			],
+			sort: ['title']
+		})
 	);
-	const academics_courses = parse(
-		AcademicsCourses,
-		await directus.request(
-			readItems('academics_courses', {
-				sort: ['course_code']
-			})
-		)
+	const academics_courses = await directus.request(
+		readItems('academics_courses', {
+			sort: ['course_code']
+		})
 	);
 
 	return { academics, academics_programs, academics_courses };

--- a/website-frontend/src/routes/academics/+page.svelte
+++ b/website-frontend/src/routes/academics/+page.svelte
@@ -24,9 +24,11 @@
 			List of programs offered by the department
 		</h1>
 		{#each academics_programs as program}
-			<ul>
-				<a href="academics/{program.category.slug}/programs/{program.slug}">{program.title}</a>
-			</ul>
+			{#if typeof program.category !== 'string'}
+				<ul>
+					<a href="academics/{program.category.slug}/programs/{program.slug}">{program.title}</a>
+				</ul>
+			{/if}
 		{/each}
 		<br />
 

--- a/website-frontend/src/routes/academics/[category]/+page.server.ts
+++ b/website-frontend/src/routes/academics/[category]/+page.server.ts
@@ -34,7 +34,12 @@ export async function load({ fetch, params }) {
 		AcademicsPrograms,
 		await directus.request(
 			readItems('academics_programs', {
-				fields: ['*', 'category.name', 'category.slug'],
+				fields: [
+					'*',
+					{
+						category: ['name', 'slug']
+					}
+				],
 				sort: ['title'],
 				filter: {
 					category: {

--- a/website-frontend/src/routes/academics/[category]/+page.server.ts
+++ b/website-frontend/src/routes/academics/[category]/+page.server.ts
@@ -1,75 +1,62 @@
 /** @type {import('./$types').PageServerLoad} */
 import getDirectusInstance from '$lib/directus';
-import { AcademicsCategories, AcademicsCategory } from '$lib/models/academics_categories';
-import { AcademicsCourses } from '$lib/models/academics_courses';
-import { AcademicsPrograms } from '$lib/models/academics_programs';
 import { readItems } from '@directus/sdk';
-import { parse } from 'valibot';
 import { error } from '@sveltejs/kit';
 
 export async function load({ fetch, params }) {
 	const directus = getDirectusInstance(fetch);
 
-	const academics_categories = parse(
-		AcademicsCategories,
-		await directus.request(
-			readItems('academics_categories', {
-				filter: {
-					slug: {
-						_eq: params.category
-					}
-				},
-				limit: 1
-			})
-		)
+	const academics_categories = await directus.request(
+		readItems('academics_categories', {
+			filter: {
+				slug: {
+					_eq: params.category
+				}
+			},
+			limit: 1
+		})
 	);
 
 	if (!academics_categories || academics_categories.length === 0) {
 		throw error(404, 'Category not found');
 	}
 
-	const academics_category = parse(AcademicsCategory, academics_categories[0]);
+	const academics_category = academics_categories[0];
 
-	const academics_programs = parse(
-		AcademicsPrograms,
-		await directus.request(
-			readItems('academics_programs', {
-				fields: [
-					'*',
-					{
-						category: ['name', 'slug']
-					}
-				],
-				sort: ['title'],
-				filter: {
-					category: {
-						slug: {
-							_eq: params.category
-						}
+	const academics_programs = await directus.request(
+		readItems('academics_programs', {
+			fields: [
+				'*',
+				{
+					category: ['name', 'slug']
+				}
+			],
+			sort: ['title'],
+			filter: {
+				category: {
+					slug: {
+						_eq: params.category
 					}
 				}
-			})
-		)
+			}
+		})
 	);
 
-	const academics_courses = parse(
-		AcademicsCourses,
-		await directus.request(
-			readItems('academics_courses', {
-				sort: ['course_code'],
-				filter: {
-					related_academics_programs: {
-						academics_programs_id: {
-							category: {
-								slug: {
-									_eq: params.category
-								}
+	const academics_courses = await directus.request(
+		readItems('academics_courses', {
+			sort: ['course_code'],
+			filter: {
+				related_academics_programs: {
+					academics_programs_id: {
+						category: {
+							slug: {
+								_eq: params.category
 							}
 						}
 					}
 				}
-			})
-		)
+			}
+		})
 	);
 
 	return { academics_category, academics_programs, academics_courses };

--- a/website-frontend/src/routes/academics/[category]/+page.svelte
+++ b/website-frontend/src/routes/academics/[category]/+page.svelte
@@ -24,9 +24,11 @@
 			{academics_category.name} programs offered by the department
 		</h1>
 		{#each academics_programs as program}
-			<ul>
-				<a href="academics/{program.category.slug}/programs/{program.slug}">{program.title}</a>
-			</ul>
+			{#if typeof program.category !== 'string'}
+				<ul>
+					<a href="academics/{program.category.slug}/programs/{program.slug}">{program.title}</a>
+				</ul>
+			{/if}
 		{/each}
 		<br />
 

--- a/website-frontend/src/routes/academics/[category]/[slug]/+page.server.ts
+++ b/website-frontend/src/routes/academics/[category]/[slug]/+page.server.ts
@@ -1,36 +1,31 @@
 /** @type {import('./$types').PageServerLoad} */
 import getDirectusInstance from '$lib/directus';
-import { AcademicsPage, AcademicsPages } from '$lib/models/academics_pages';
 import { readItems } from '@directus/sdk';
-import { parse } from 'valibot';
 import { error } from '@sveltejs/kit';
 
 export async function load({ fetch, params }) {
 	const directus = getDirectusInstance(fetch);
-	const academics_pages = parse(
-		AcademicsPages,
-		await directus.request(
-			readItems('academics_pages', {
-				filter: {
-					category: {
-						slug: {
-							_eq: params.category
-						}
-					},
+	const academics_pages = await directus.request(
+		readItems('academics_pages', {
+			filter: {
+				category: {
 					slug: {
-						_eq: params.slug
+						_eq: params.category
 					}
 				},
-				limit: 1
-			})
-		)
+				slug: {
+					_eq: params.slug
+				}
+			},
+			limit: 1
+		})
 	);
 
 	if (!academics_pages || academics_pages.length === 0) {
 		throw error(404, 'Page not found');
 	}
 
-	const academics_page = parse(AcademicsPage, academics_pages[0]);
+	const academics_page = academics_pages[0];
 
 	return { academics_page };
 }

--- a/website-frontend/src/routes/academics/[category]/courses/+page.server.ts
+++ b/website-frontend/src/routes/academics/[category]/courses/+page.server.ts
@@ -1,52 +1,43 @@
 /** @type {import('./$types').PageServerLoad} */
 import getDirectusInstance from '$lib/directus';
-import { AcademicsCategories, AcademicsCategory } from '$lib/models/academics_categories';
-import { AcademicsCourses } from '$lib/models/academics_courses';
 import { readItems } from '@directus/sdk';
-import { parse } from 'valibot';
 import { error } from '@sveltejs/kit';
 
 export async function load({ fetch, params }) {
 	const directus = getDirectusInstance(fetch);
 
-	const academics_categories = parse(
-		AcademicsCategories,
-		await directus.request(
-			readItems('academics_categories', {
-				filter: {
-					slug: {
-						_eq: params.category
-					}
-				},
-				limit: 1
-			})
-		)
+	const academics_categories = await directus.request(
+		readItems('academics_categories', {
+			filter: {
+				slug: {
+					_eq: params.category
+				}
+			},
+			limit: 1
+		})
 	);
 
 	if (!academics_categories || academics_categories.length === 0) {
 		throw error(404, 'Category not found');
 	}
 
-	const academics_category = parse(AcademicsCategory, academics_categories[0]);
+	const academics_category = academics_categories[0];
 
-	const academics_courses = parse(
-		AcademicsCourses,
-		await directus.request(
-			readItems('academics_courses', {
-				sort: ['course_code'],
-				filter: {
-					related_academics_programs: {
-						academics_programs_id: {
-							category: {
-								slug: {
-									_eq: params.category
-								}
+	const academics_courses = await directus.request(
+		readItems('academics_courses', {
+			sort: ['course_code'],
+			filter: {
+				related_academics_programs: {
+					academics_programs_id: {
+						category: {
+							slug: {
+								_eq: params.category
 							}
 						}
 					}
 				}
-			})
-		)
+			}
+		})
 	);
 
 	return { academics_category, academics_courses };

--- a/website-frontend/src/routes/academics/[category]/courses/+page.svelte
+++ b/website-frontend/src/routes/academics/[category]/courses/+page.svelte
@@ -1,7 +1,6 @@
 <script>
 	/** @type {import('./$types').PageData} */
 	import Banner from '$lib/components/banner/Banner.svelte';
-	import FlexibleContent from '$lib/components/flexible_content/FlexibleContent.svelte';
 	import DataTable from '$lib/components/table/DataTable.svelte';
 
 	export let data;

--- a/website-frontend/src/routes/academics/[category]/programs/[slug]/+page.server.ts
+++ b/website-frontend/src/routes/academics/[category]/programs/[slug]/+page.server.ts
@@ -11,7 +11,12 @@ export async function load({ fetch, params }) {
 		AcademicsPrograms,
 		await directus.request(
 			readItems('academics_programs', {
-				fields: ['*', 'curriculum_table.*'],
+				fields: [
+					'*',
+					{
+						curriculum_table: ['*']
+					}
+				],
 				filter: {
 					category: {
 						slug: {

--- a/website-frontend/src/routes/academics/[category]/programs/[slug]/+page.server.ts
+++ b/website-frontend/src/routes/academics/[category]/programs/[slug]/+page.server.ts
@@ -1,42 +1,37 @@
 /** @type {import('./$types').PageServerLoad} */
 import getDirectusInstance from '$lib/directus';
-import { AcademicsProgram, AcademicsPrograms } from '$lib/models/academics_programs';
 import { readItems } from '@directus/sdk';
-import { parse } from 'valibot';
 import { error } from '@sveltejs/kit';
 
 export async function load({ fetch, params }) {
 	const directus = getDirectusInstance(fetch);
-	const academics_programs = parse(
-		AcademicsPrograms,
-		await directus.request(
-			readItems('academics_programs', {
-				fields: [
-					'*',
-					{
-						curriculum_table: ['*']
-					}
-				],
-				filter: {
-					category: {
-						slug: {
-							_eq: params.category
-						}
-					},
+	const academics_programs = await directus.request(
+		readItems('academics_programs', {
+			fields: [
+				'*',
+				{
+					curriculum_table: ['*']
+				}
+			],
+			filter: {
+				category: {
 					slug: {
-						_eq: params.slug
+						_eq: params.category
 					}
 				},
-				limit: 1
-			})
-		)
+				slug: {
+					_eq: params.slug
+				}
+			},
+			limit: 1
+		})
 	);
 
 	if (!academics_programs || academics_programs.length === 0) {
 		throw error(404, 'Program not found');
 	}
 
-	const academics_program = parse(AcademicsProgram, academics_programs[0]);
+	const academics_program = academics_programs[0];
 
 	return { academics_program };
 }

--- a/website-frontend/src/routes/academics/[category]/programs/[slug]/+page.svelte
+++ b/website-frontend/src/routes/academics/[category]/programs/[slug]/+page.svelte
@@ -25,6 +25,7 @@
 		</h1>
 		{#if academics_program.curriculum_table}
 			{#each [...new Set(academics_program.curriculum_table
+						.filter((item) => typeof item !== 'number')
 						.map((item) => item.year)
 						.sort((a, b) => a - b))] as year}
 				Year {year}
@@ -32,25 +33,25 @@
 				First semester
 				<br />
 				<DataTable
-					data={academics_program.curriculum_table.filter(
-						(item) => item.year === year && item.semester === 'first'
-					)}
+					data={academics_program.curriculum_table
+						.filter((item) => typeof item !== 'number')
+						.filter((item) => item.year === year && item.semester === 'first')}
 				/>
 				<br />
 				Second semester
 				<br />
 				<DataTable
-					data={academics_program.curriculum_table.filter(
-						(item) => item.year === year && item.semester === 'second'
-					)}
+					data={academics_program.curriculum_table
+						.filter((item) => typeof item !== 'number')
+						.filter((item) => item.year === year && item.semester === 'second')}
 				/>
 				<br />
 				Midyear
 				<br />
 				<DataTable
-					data={academics_program.curriculum_table.filter(
-						(item) => item.year === year && item.semester === 'midyear'
-					)}
+					data={academics_program.curriculum_table
+						.filter((item) => typeof item !== 'number')
+						.filter((item) => item.year === year && item.semester === 'midyear')}
 				/>
 			{/each}
 		{/if}

--- a/website-frontend/src/routes/events/+page.server.ts
+++ b/website-frontend/src/routes/events/+page.server.ts
@@ -1,8 +1,6 @@
 /** @type {import('./$types').PageServerLoad} */
 import getDirectusInstance from '$lib/directus';
-import { Events } from '$lib/models/event';
 import { readItems } from '@directus/sdk';
-import { parse } from 'valibot';
 
 export async function load({ fetch, url }) {
 	const directus = getDirectusInstance(fetch);
@@ -36,112 +34,7 @@ export async function load({ fetch, url }) {
 		.then((res) => res.map(({ name }) => name));
 	const events = await (async () => {
 		if (filters.time === 'past') {
-			return parse(
-				Events,
-				await directus.request(
-					readItems('events', {
-						fields: [
-							'*',
-							{
-								event_area: ['name']
-							},
-							{
-								event_tags: [
-									{
-										events_tags_id: ['name']
-									}
-								]
-							}
-						],
-						filter: {
-							_and: [
-								{
-									event_area: {
-										name: { _in: filters.locations.length !== 0 ? filters.locations : undefined }
-									}
-								},
-								{
-									event_tags: {
-										events_tags_id: {
-											name: {
-												_in: filters.disciplines.length !== 0 ? filters.disciplines : undefined
-											}
-										}
-									}
-								},
-								{
-									_or: [
-										{
-											_and: [
-												{
-													end_date: {
-														_null: true
-													}
-												},
-												{
-													start_date: {
-														_lte: '$NOW'
-													}
-												}
-											]
-										},
-										{
-											end_date: {
-												_nnull: true,
-												_lte: '$NOW'
-											}
-										}
-									]
-								}
-							]
-						}
-					})
-				)
-			);
-		}
-		if (filters.time === 'all') {
-			return parse(
-				Events,
-				await directus.request(
-					readItems('events', {
-						fields: [
-							'*',
-							{
-								event_area: ['name']
-							},
-							{
-								event_tags: [
-									{
-										events_tags_id: ['name']
-									}
-								]
-							}
-						],
-						filter: {
-							_and: [
-								{
-									event_area: {
-										name: { _in: filters.locations.length !== 0 ? filters.locations : undefined }
-									}
-								},
-								{
-									event_tags: {
-										events_tags_id: {
-											name: {
-												_in: filters.disciplines.length !== 0 ? filters.disciplines : undefined
-											}
-										}
-									}
-								}
-							]
-						}
-					})
-				)
-			);
-		}
-		return parse(
-			Events,
-			await directus.request(
+			return await directus.request(
 				readItems('events', {
 					fields: [
 						'*',
@@ -173,14 +66,110 @@ export async function load({ fetch, url }) {
 								}
 							},
 							{
-								start_date: {
-									_gte: '$NOW'
+								_or: [
+									{
+										_and: [
+											{
+												end_date: {
+													_null: true
+												}
+											},
+											{
+												start_date: {
+													_lte: '$NOW'
+												}
+											}
+										]
+									},
+									{
+										end_date: {
+											_nnull: true,
+											_lte: '$NOW'
+										}
+									}
+								]
+							}
+						]
+					}
+				})
+			);
+		}
+		if (filters.time === 'all') {
+			return await directus.request(
+				readItems('events', {
+					fields: [
+						'*',
+						{
+							event_area: ['name']
+						},
+						{
+							event_tags: [
+								{
+									events_tags_id: ['name']
+								}
+							]
+						}
+					],
+					filter: {
+						_and: [
+							{
+								event_area: {
+									name: { _in: filters.locations.length !== 0 ? filters.locations : undefined }
+								}
+							},
+							{
+								event_tags: {
+									events_tags_id: {
+										name: {
+											_in: filters.disciplines.length !== 0 ? filters.disciplines : undefined
+										}
+									}
 								}
 							}
 						]
 					}
 				})
-			)
+			);
+		}
+		return await directus.request(
+			readItems('events', {
+				fields: [
+					'*',
+					{
+						event_area: ['name']
+					},
+					{
+						event_tags: [
+							{
+								events_tags_id: ['name']
+							}
+						]
+					}
+				],
+				filter: {
+					_and: [
+						{
+							event_area: {
+								name: { _in: filters.locations.length !== 0 ? filters.locations : undefined }
+							}
+						},
+						{
+							event_tags: {
+								events_tags_id: {
+									name: {
+										_in: filters.disciplines.length !== 0 ? filters.disciplines : undefined
+									}
+								}
+							}
+						},
+						{
+							start_date: {
+								_gte: '$NOW'
+							}
+						}
+					]
+				}
+			})
 		);
 	})();
 

--- a/website-frontend/src/routes/events/+page.server.ts
+++ b/website-frontend/src/routes/events/+page.server.ts
@@ -40,7 +40,19 @@ export async function load({ fetch, url }) {
 				Events,
 				await directus.request(
 					readItems('events', {
-						fields: ['*', 'event_area.name', 'event_tags.events_tags_id.name'],
+						fields: [
+							'*',
+							{
+								event_area: ['name']
+							},
+							{
+								event_tags: [
+									{
+										events_tags_id: ['name']
+									}
+								]
+							}
+						],
 						filter: {
 							_and: [
 								{
@@ -92,7 +104,19 @@ export async function load({ fetch, url }) {
 				Events,
 				await directus.request(
 					readItems('events', {
-						fields: ['*', 'event_area.name', 'event_tags.events_tags_id.name'],
+						fields: [
+							'*',
+							{
+								event_area: ['name']
+							},
+							{
+								event_tags: [
+									{
+										events_tags_id: ['name']
+									}
+								]
+							}
+						],
 						filter: {
 							_and: [
 								{
@@ -119,7 +143,19 @@ export async function load({ fetch, url }) {
 			Events,
 			await directus.request(
 				readItems('events', {
-					fields: ['*', 'event_area.name', 'event_tags.events_tags_id.name'],
+					fields: [
+						'*',
+						{
+							event_area: ['name']
+						},
+						{
+							event_tags: [
+								{
+									events_tags_id: ['name']
+								}
+							]
+						}
+					],
 					filter: {
 						_and: [
 							{

--- a/website-frontend/src/routes/events/[slug]/+page.server.ts
+++ b/website-frontend/src/routes/events/[slug]/+page.server.ts
@@ -68,7 +68,6 @@ export async function load({ params, fetch }) {
 
 	const related_events = (() => {
 		if (!event.event_tags) return [];
-		if (event.event_tags.length == 0) return [];
 		return event_tags
 			.filter((item) => typeof item !== 'string')
 			.filter(({ events_id }, index) => {

--- a/website-frontend/src/routes/events/[slug]/+page.server.ts
+++ b/website-frontend/src/routes/events/[slug]/+page.server.ts
@@ -2,58 +2,53 @@
 import { readItems } from '@directus/sdk';
 import getDirectusInstance from '$lib/directus';
 import { error } from '@sveltejs/kit';
-import { Events } from '$lib/models/event';
-import { parse } from 'valibot';
 
 export async function load({ params, fetch }) {
 	const directus = getDirectusInstance(fetch);
 	const eventSlug = params.slug;
 
-	const events = parse(
-		Events,
-		await directus.request(
-			readItems('events', {
-				fields: [
-					'*',
-					{
-						event_area: ['name']
-					},
-					{
-						event_tags: [
-							{
-								events_tags_id: [
-									'name',
-									{
-										related_events: [
-											{
-												events_id: [
-													'*',
-													{
-														event_area: ['name']
-													},
-													{
-														event_tags: [
-															{
-																events_tags_id: ['name']
-															}
-														]
-													}
-												]
-											}
-										]
-									}
-								]
-							}
-						]
-					}
-				],
-				filter: {
-					slug: {
-						_eq: eventSlug
-					}
+	const events = await directus.request(
+		readItems('events', {
+			fields: [
+				'*',
+				{
+					event_area: ['name']
+				},
+				{
+					event_tags: [
+						{
+							events_tags_id: [
+								'name',
+								{
+									related_events: [
+										{
+											events_id: [
+												'*',
+												{
+													event_area: ['name']
+												},
+												{
+													event_tags: [
+														{
+															events_tags_id: ['name']
+														}
+													]
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
 				}
-			})
-		)
+			],
+			filter: {
+				slug: {
+					_eq: eventSlug
+				}
+			}
+		})
 	);
 
 	if (!events.length) {

--- a/website-frontend/src/routes/events/[slug]/+page.server.ts
+++ b/website-frontend/src/routes/events/[slug]/+page.server.ts
@@ -57,35 +57,36 @@ export async function load({ params, fetch }) {
 
 	const event = events[0];
 	const event_tags = event.event_tags
-		.map((item) => {
-			if (typeof item === 'string') return [];
-			if (typeof item.events_tags_id === 'string') return [];
-			return item.events_tags_id?.related_events ?? [];
-		})
-		.flat();
+		? event.event_tags
+				.map((item) => {
+					if (typeof item === 'string') return [];
+					if (typeof item.events_tags_id === 'string') return [];
+					return item.events_tags_id?.related_events ?? [];
+				})
+				.flat()
+		: [];
 
 	const related_events = (() => {
-		if (event.event_tags.length != 0) {
-			return event_tags
-				.filter((item) => typeof item !== 'string')
-				.filter(({ events_id }, index) => {
-					if (typeof events_id !== 'string') {
-						return (
-							events_id?.id != event.id &&
-							!event_tags
-								.filter((item) => typeof item !== 'string')
-								.map(({ events_id }) => {
-									if (typeof events_id !== 'string') {
-										return events_id?.id;
-									}
-								})
-								.includes(events_id?.id, index + 1)
-						);
-					}
-				})
-				.map((res) => res.events_id);
-		}
-		return [];
+		if (!event.event_tags) return [];
+		if (event.event_tags.length == 0) return [];
+		return event_tags
+			.filter((item) => typeof item !== 'string')
+			.filter(({ events_id }, index) => {
+				if (typeof events_id !== 'string') {
+					return (
+						events_id?.id != event.id &&
+						!event_tags
+							.filter((item) => typeof item !== 'string')
+							.map(({ events_id }) => {
+								if (typeof events_id !== 'string') {
+									return events_id?.id;
+								}
+							})
+							.includes(events_id?.id, index + 1)
+					);
+				}
+			})
+			.map((res) => res.events_id);
 	})();
 
 	return { event, related_events };

--- a/website-frontend/src/routes/events/[slug]/+page.server.ts
+++ b/website-frontend/src/routes/events/[slug]/+page.server.ts
@@ -1,7 +1,9 @@
 /** @type {import('./$types').PageServerLoad} */
+import { Event } from '$lib/models/event';
 import { readItems } from '@directus/sdk';
 import getDirectusInstance from '$lib/directus';
 import { error } from '@sveltejs/kit';
+import { parse } from 'valibot';
 
 export async function load({ params, fetch }) {
 	const directus = getDirectusInstance(fetch);
@@ -55,7 +57,7 @@ export async function load({ params, fetch }) {
 		throw error(404, 'Event not found');
 	}
 
-	const event = events[0];
+	const event = parse(Event, events[0]);
 	const event_tags = event.event_tags
 		? event.event_tags
 				.map((item) => {

--- a/website-frontend/src/routes/events/[slug]/+page.server.ts
+++ b/website-frontend/src/routes/events/[slug]/+page.server.ts
@@ -3,7 +3,6 @@ import { Event } from '$lib/models/event';
 import { readItems } from '@directus/sdk';
 import getDirectusInstance from '$lib/directus';
 import { error } from '@sveltejs/kit';
-import { parse } from 'valibot';
 
 export async function load({ params, fetch }) {
 	const directus = getDirectusInstance(fetch);
@@ -57,7 +56,7 @@ export async function load({ params, fetch }) {
 		throw error(404, 'Event not found');
 	}
 
-	const event = parse(Event, events[0]);
+	const event = events[0] as Event;
 	const event_tags = event.event_tags
 		? event.event_tags
 				.map((item) => {

--- a/website-frontend/src/routes/events/[slug]/+page.server.ts
+++ b/website-frontend/src/routes/events/[slug]/+page.server.ts
@@ -15,11 +15,37 @@ export async function load({ params, fetch }) {
 			readItems('events', {
 				fields: [
 					'*',
-					'event_area.name',
-					'event_tags.events_tags_id.name',
-					'event_tags.events_tags_id.related_events.events_id.*',
-					'event_tags.events_tags_id.related_events.events_id.event_area.name',
-					'event_tags.events_tags_id.related_events.events_id.event_tags.events_tags_id.name'
+					{
+						event_area: ['name']
+					},
+					{
+						event_tags: [
+							{
+								events_tags_id: [
+									'name',
+									{
+										related_events: [
+											{
+												events_id: [
+													'*',
+													{
+														event_area: ['name']
+													},
+													{
+														event_tags: [
+															{
+																events_tags_id: ['name']
+															}
+														]
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
 				],
 				filter: {
 					slug: {

--- a/website-frontend/src/routes/events/[slug]/+page.svelte
+++ b/website-frontend/src/routes/events/[slug]/+page.svelte
@@ -20,7 +20,7 @@
 	</div>
 
 	<div class="px-4 py-14 md:px-64 md:py-16">
-		<FlexibleContent content={event.event_content}/>
+		<FlexibleContent content={event.event_content} />
 	</div>
 
 	{#if related_events}

--- a/website-frontend/src/routes/events/[slug]/+page.svelte
+++ b/website-frontend/src/routes/events/[slug]/+page.svelte
@@ -32,7 +32,9 @@
 			md:my-8 md:max-w-[80vw] md:grid-cols-4 md:gap-4"
 		>
 			{#each related_events as related_event}
-				<FeaturedEventCard event={related_event} />
+				{#if typeof related_event !== 'string'}
+					<FeaturedEventCard event={related_event} />
+				{/if}
 			{/each}
 		</div>
 	{/if}

--- a/website-frontend/src/routes/news/[slug]/+page.server.ts
+++ b/website-frontend/src/routes/news/[slug]/+page.server.ts
@@ -9,10 +9,12 @@ export async function load({ params, fetch }) {
 		readItems('news', {
 			fields: [
 				'*',
-				'user_created.first_name',
-				'user_created.last_name',
-				'user_updated.first_name',
-				'user_updated.last_name'
+				{
+					user_created: ['first_name', 'last_name']
+				},
+				{
+					user_updated: ['first_name', 'last_name']
+				}
 			],
 			filter: {
 				slug: {

--- a/website-frontend/src/routes/people/+page.server.ts
+++ b/website-frontend/src/routes/people/+page.server.ts
@@ -1,14 +1,11 @@
 /** @type {import('./$types').PageServerLoad} */
 import { readItems, readSingleton } from '@directus/sdk';
-import { parse } from 'valibot';
-import { People } from '$lib/models/people';
-import { PeopleOverview } from '$lib/models/people_overview';
 import getDirectusInstance from '$lib/directus';
 
 export async function load({ fetch }) {
 	const directus = getDirectusInstance(fetch);
-	return {
-		people: parse(People, await directus.request(readItems('people'))),
-		people_overview: parse(PeopleOverview, await directus.request(readSingleton('people_overview')))
-	};
+	const people = await directus.request(readItems('people'));
+	const people_overview = await directus.request(readSingleton('people_overview'));
+
+	return { people, people_overview };
 }

--- a/website-frontend/src/routes/people/[slug]/+page.server.ts
+++ b/website-frontend/src/routes/people/[slug]/+page.server.ts
@@ -1,7 +1,5 @@
 /** @type {import('./$types').PageServerLoad} */
 import { readItems } from '@directus/sdk';
-import { parse } from 'valibot';
-import { People } from '$lib/models/people';
 import getDirectusInstance from '$lib/directus';
 import { error } from '@sveltejs/kit';
 
@@ -25,21 +23,14 @@ export async function load({ params, fetch }) {
 
 	const category = categories[0];
 
-	const people = parse(
-		People,
-		await directus.request(
-			readItems('people', {
-				filter: {
-					category: {
-						_eq: category.title
-					}
+	const people = await directus.request(
+		readItems('people', {
+			filter: {
+				category: {
+					_eq: category.title
 				}
-			})
-		)
+			}
+		})
 	);
-
-	return {
-		category,
-		people
-	};
+	return { category, people };
 }

--- a/website-frontend/src/routes/people/[slug]/[username]/+page.server.ts
+++ b/website-frontend/src/routes/people/[slug]/[username]/+page.server.ts
@@ -1,7 +1,5 @@
 /** @type {import('./$types').PageServerLoad} */
 import { readItems } from '@directus/sdk';
-import { parse } from 'valibot';
-import { Person } from '$lib/models/people';
 import getDirectusInstance from '$lib/directus';
 import { error } from '@sveltejs/kit';
 
@@ -22,12 +20,12 @@ export async function load({ params, fetch }) {
 		throw error(404, 'Person not found');
 	}
 
-	const personId = people[0].id;
+	const person = people[0];
 
 	const labAssociations = await directus.request(
 		readItems('people_laboratories', {
 			filter: {
-				people_id: { _eq: personId }
+				people_id: { _eq: person.id }
 			}
 		})
 	);
@@ -44,8 +42,5 @@ export async function load({ params, fetch }) {
 				)
 			: [];
 
-	return {
-		person: parse(Person, people[0]),
-		laboratories
-	};
+	return { person, laboratories };
 }

--- a/website-frontend/src/routes/publications/+page.server.ts
+++ b/website-frontend/src/routes/publications/+page.server.ts
@@ -1,21 +1,13 @@
 /** @type {import('./$types').PageServerLoad} */
 import { readItems } from '@directus/sdk';
-import { parse } from 'valibot';
-import { Publications } from '$lib/models/publications';
 import getDirectusInstance from '$lib/directus';
 
 export async function load({ fetch }) {
 	const directus = getDirectusInstance(fetch);
-	const publications = parse(
-		Publications,
-		await directus.request(
-			readItems('publications', {
-				sort: '-publish_date'
-			})
-		)
+	const publications = await directus.request(
+		readItems('publications', {
+			sort: '-publish_date'
+		})
 	);
-
-	return {
-		publications
-	};
+	return { publications };
 }

--- a/website-frontend/src/routes/publications/+page.svelte
+++ b/website-frontend/src/routes/publications/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	/** @type {import('./$types').PageData} */
 	import Banner from '$lib/components/banner/Banner.svelte';
-	import LoadMore from '$lib/components/load_more/LoadMore.svelte';
+	import LoadMore from '$lib/components/buttons/LoadMore.svelte';
 	import { PUBLIC_APIURL } from '$env/static/public';
 
 	export let data;

--- a/website-frontend/src/routes/research/+page.server.ts
+++ b/website-frontend/src/routes/research/+page.server.ts
@@ -1,12 +1,10 @@
 /** @type {import('./$types').PageServerLoad} */
 import { readItems } from '@directus/sdk';
-import { parse } from 'valibot';
 import getDirectusInstance from '$lib/directus';
-import { Laboratories } from '$lib/models/laboratories';
 
 export async function load({ fetch }) {
 	const directus = getDirectusInstance(fetch);
-	return {
-		laboratories: parse(Laboratories, await directus.request(readItems('laboratories')))
-	};
+	const laboratories = await directus.request(readItems('laboratories'));
+
+	return { laboratories };
 }

--- a/website-frontend/src/routes/research/labs/[slug]/+page.server.ts
+++ b/website-frontend/src/routes/research/labs/[slug]/+page.server.ts
@@ -13,7 +13,16 @@ export async function load({ params, fetch }) {
 				slug: { _eq: slug }
 			},
 			limit: 1,
-			fields: ['*', 'background_images.directus_files_id.*']
+			fields: [
+				'*',
+				{
+					background_images: [
+						{
+							directus_files_id: ['id']
+						}
+					]
+				}
+			]
 		})
 	);
 

--- a/website-frontend/src/routes/research/labs/[slug]/+page.svelte
+++ b/website-frontend/src/routes/research/labs/[slug]/+page.svelte
@@ -8,7 +8,14 @@
 	const { laboratory } = data;
 
 	const background_images = laboratory.background_images
-		? laboratory.background_images.map((img) => img.directus_files_id.id)
+		? laboratory.background_images
+				.filter((img) => typeof img !== 'string')
+				.map((img) => {
+					if (typeof img.directus_files_id !== 'string') {
+						return img.directus_files_id.id;
+					}
+					return '';
+				})
 		: [];
 
 	let showFull = false;

--- a/website-frontend/src/routes/students/+page.server.ts
+++ b/website-frontend/src/routes/students/+page.server.ts
@@ -1,15 +1,10 @@
 /** @type {import('./$types').PageServerLoad} */
 import { readSingleton } from '@directus/sdk';
-import { parse } from 'valibot';
-import { StudentsOverview } from '$lib/models/students_overview';
 import getDirectusInstance from '$lib/directus';
 
 export async function load({ fetch }) {
 	const directus = getDirectusInstance(fetch);
-	return {
-		students_overview: parse(
-			StudentsOverview,
-			await directus.request(readSingleton('students_overview'))
-		)
-	};
+	const students_overview = await directus.request(readSingleton('students_overview'));
+
+	return { students_overview };
 }

--- a/website-frontend/src/routes/students/organizations/+page.server.ts
+++ b/website-frontend/src/routes/students/organizations/+page.server.ts
@@ -1,20 +1,13 @@
 /** @type {import('./$types').PageServerLoad} */
 import { readItems, readSingleton } from '@directus/sdk';
 import getDirectusInstance from '$lib/directus';
-import { parse } from 'valibot';
-import { StudentsOrganizations } from '$lib/models/students_organizations';
-import { StudentsOrganizationsOverview } from '$lib/models/students_organizations_overview';
 
 export async function load({ fetch }) {
 	const directus = await getDirectusInstance(fetch);
-	return {
-		students_organizations: parse(
-			StudentsOrganizations,
-			await directus.request(readItems('students_organizations'))
-		),
-		students_organizations_overview: parse(
-			StudentsOrganizationsOverview,
-			await directus.request(readSingleton('students_organizations_overview'))
-		)
-	};
+	const students_organizations = await directus.request(readItems('students_organizations'));
+	const students_organizations_overview = await directus.request(
+		readSingleton('students_organizations_overview')
+	);
+
+	return { students_organizations, students_organizations_overview };
 }

--- a/website-frontend/src/routes/students/organizations/[slug]/+page.server.ts
+++ b/website-frontend/src/routes/students/organizations/[slug]/+page.server.ts
@@ -2,6 +2,8 @@
 import { readItems } from '@directus/sdk';
 import getDirectusInstance from '$lib/directus';
 import { error } from '@sveltejs/kit';
+import { StudentsOrganization } from '$lib/models/students_organizations.js';
+import { parse } from 'valibot';
 
 export async function load({ params, fetch }) {
 	const directus = getDirectusInstance(fetch);
@@ -27,11 +29,11 @@ export async function load({ params, fetch }) {
 		})
 	);
 
+	const organization = parse(StudentsOrganization, organizations[0]);
+
 	if (!organizations || organizations.length === 0) {
 		throw error(404, 'Organization not found');
 	}
 
-	return {
-		organization: organizations[0]
-	};
+	return { organization };
 }

--- a/website-frontend/src/routes/students/organizations/[slug]/+page.server.ts
+++ b/website-frontend/src/routes/students/organizations/[slug]/+page.server.ts
@@ -14,7 +14,16 @@ export async function load({ params, fetch }) {
 					_eq: organizationSlug
 				}
 			},
-			fields: ['*', 'background_images.directus_files_id.*']
+			fields: [
+				'*',
+				{
+					background_images: [
+						{
+							directus_files_id: ['id']
+						}
+					]
+				}
+			]
 		})
 	);
 

--- a/website-frontend/src/routes/students/organizations/[slug]/+page.server.ts
+++ b/website-frontend/src/routes/students/organizations/[slug]/+page.server.ts
@@ -1,9 +1,8 @@
 /** @type {import('./$types').PageServerLoad} */
+import type { StudentsOrganization } from '$lib/models/students_organizations.js';
 import { readItems } from '@directus/sdk';
 import getDirectusInstance from '$lib/directus';
 import { error } from '@sveltejs/kit';
-import { StudentsOrganization } from '$lib/models/students_organizations.js';
-import { parse } from 'valibot';
 
 export async function load({ params, fetch }) {
 	const directus = getDirectusInstance(fetch);
@@ -29,7 +28,7 @@ export async function load({ params, fetch }) {
 		})
 	);
 
-	const organization = parse(StudentsOrganization, organizations[0]);
+	const organization = organizations[0] as StudentsOrganization;
 
 	if (!organizations || organizations.length === 0) {
 		throw error(404, 'Organization not found');

--- a/website-frontend/src/routes/students/organizations/[slug]/+page.svelte
+++ b/website-frontend/src/routes/students/organizations/[slug]/+page.svelte
@@ -11,7 +11,14 @@
 	let showFull = false;
 
 	const background_images = organization.background_images
-		? organization.background_images.map((img) => img.directus_files_id.id)
+		? organization.background_images
+				.filter((img) => typeof img !== 'string')
+				.map((img) => {
+					if (typeof img.directus_files_id !== 'string') {
+						return img.directus_files_id.id;
+					}
+					return '';
+				})
 		: [];
 </script>
 
@@ -39,7 +46,7 @@
 				founding_date={organization.founding_date ?? ''}
 			/>
 
-			<FlexibleContent content={organization.flexible_content} isDark={true} />
+			<FlexibleContent content={organization.flexible_content} />
 
 			<div class="text-lg leading-normal text-primary-foreground">
 				<div class="text-lg leading-normal text-primary-foreground">

--- a/website-frontend/src/routes/students/organizations/[slug]/+page.svelte
+++ b/website-frontend/src/routes/students/organizations/[slug]/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	/** @type {import('./$types').PageData} */
-	import { onMount, tick } from 'svelte';
 	import Hero from '$lib/components/carousels/LabHero.svelte';
 	import InfoCard from '$lib/components/cards/InfoCard.svelte';
 	import ReadMore from '$lib/components/buttons/ReadMore.svelte';


### PR DESCRIPTION
This PR solves numerous existing code quality check errors in ESLint and `svelte-check`. This PR also removes Valibot `parse` for fetching Directus requests (for now), although the parsing is maintained in accessing individual elements returned by Directus requests.

The documented changes are as follows:
- Use the Directus M2A fields syntax for fetching specific fields of M2M collections
- Remove `partial` schema typing for models
- Use conditional rendering in accessing intended object properties inside `.svelte` files
- Remove unused variables in project components
- Use Valibot `parse` only for accessing individual elements from a fetched Directus collection