### PR TITLE
fix: properly load Inter font from Google Fonts

### DIFF
--- a/website-frontend/src/app.html
+++ b/website-frontend/src/app.html
@@ -3,6 +3,12 @@
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width" />
+		<link rel="preconnect" href="https://fonts.googleapis.com" />
+		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+		<link
+			href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap"
+			rel="stylesheet"
+		/>
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover" data-theme="skeleton">

--- a/website-frontend/src/app.postcss
+++ b/website-frontend/src/app.postcss
@@ -2,6 +2,7 @@
 @tailwind components;
 @tailwind utilities;
 
+
 @layer base {
 	:root {
 		--background: 0 0% 100%;
@@ -37,6 +38,8 @@
 		--radius: 0.5rem;
 
 		--header: 222 38% 95%;
+
+		--font-family: 'Inter', sans-serif;
 	}
 }
 
@@ -49,16 +52,6 @@
 	}
 	header {
 		@apply bg-header;
-	}
-}
-
-@layer base {
-	@font-face {
-		font-family: 'Inter', serif;
-		font-optical-sizing: auto;
-		font-weight: 700;
-		font-style: normal;
-		src: url('https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap');
 	}
 }
 

--- a/website-frontend/tailwind.config.ts
+++ b/website-frontend/tailwind.config.ts
@@ -57,7 +57,7 @@ const config: Config = {
 				sm: 'calc(var(--radius) - 4px)'
 			},
 			fontFamily: {
-				sans: ['"Inter"', ...fontFamily.sans]
+				sans: ['Inter', ...fontFamily.sans]
 			}
 		}
 	},


### PR DESCRIPTION
This pull request involves updating the font family to use the 'Inter' font directly from Google Fonts and cleaning up the CSS configuration.

* Added preconnect links and stylesheet link to load 'Inter' font from Google Fonts.
* Added `--font-family` variable for 'Inter' font and removed the redundant `@font-face` declaration.
* Updated `fontFamily` configuration to use 'Inter' without quotes.