### PR TITLE
fix: proper deslugify when word has apostrophe

### DIFF
--- a/website-frontend/src/lib/utils.ts
+++ b/website-frontend/src/lib/utils.ts
@@ -3,10 +3,11 @@ export function deslugify(slug: string): string {
 	return slug
 		.replace(/_/g, ' ')
 		.replace(/-/g, ' ')
-		.replace(/\b\w+/g, (word, index) => {
+		.replace(/\b\w+('\w+)?/g, (word, index) => {
 			if (word === 'id') return 'ID';
 			if (index === 0 || !articles.includes(word)) {
-				return word.charAt(0).toUpperCase() + word.slice(1);
+				// Only capitalize the first character of the word
+				return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
 			}
 			return word;
 		});


### PR DESCRIPTION
This pull request includes a small change to the `deslugify` function in the `website-frontend/src/lib/utils.ts` file. The change ensures that words with apostrophes are correctly handled and that only the first character of each word is capitalized, while the rest of the word is converted to lowercase.

Can be observed when Citizen's Charter is passed as `page.title` for the `<Banner>` and returns Citizen'S Charter after deslugification.