### PR TITLE
feat: adjust people pages

### DIFF
--- a/website-frontend/src/lib/components/banners/PeopleBanner.svelte
+++ b/website-frontend/src/lib/components/banners/PeopleBanner.svelte
@@ -13,17 +13,6 @@
 	export let laboratory: string = '';
 	export let category: string = '';
 	export let website: string = '';
-
-	const copyToClipboard = async () => {
-		if (!email) return;
-
-		try {
-			await navigator.clipboard.writeText(email);
-			alert(`Copied: ${email}`);
-		} catch (err) {
-			console.error('Failed to copy:', err);
-		}
-	};
 </script>
 
 <div class="bg-[#343541]">
@@ -81,19 +70,20 @@
 
 					<div class="mt-5 flex space-x-1 lg:mt-0">
 						<div class="group relative">
-							<Button
-								class="max-w-xs rounded-full bg-background/20 px-3 hover:bg-background/30"
-								on:click={copyToClipboard}
-								aria-label="Copy {first_name} {last_name}'s email to clipboard"
-							>
-								<Mail class="h-4 w-4" />
-							</Button>
+							<a href="mailto:{email}" class="max-w-xs">
+								<Button
+									class="w-full rounded-full bg-background/20 px-3 hover:bg-background/30"
+									aria-label="Send an email to {first_name} {last_name}"
+								>
+									<Mail class="h-4 w-4" />
+								</Button>
+							</a>
 							<span
 								class="absolute bottom-full left-1/2 mb-2 hidden -translate-x-1/2 rounded bg-white px-2 py-1 text-xs text-primary group-hover:block"
 							>
 								{email}
 							</span>
-						</div>
+						</div>						
 
 						{#if website}
 							<a href={website} target="_blank" rel="noopener noreferrer" class="max-w-xs">

--- a/website-frontend/src/lib/components/banners/PeopleBanner.svelte
+++ b/website-frontend/src/lib/components/banners/PeopleBanner.svelte
@@ -12,6 +12,7 @@
 	export let email: string = '';
 	export let laboratory: string = '';
 	export let category: string = '';
+	export let website: string = '';
 
 	const copyToClipboard = async () => {
 		if (!email) return;
@@ -94,12 +95,21 @@
 							</span>
 						</div>
 
-						<Button
-							class="max-w-xs rounded-full bg-background/20 px-3 hover:bg-background/30"
-							aria-label="Go to {first_name} {last_name}'s website"
-						>
-							<Globe class="h-4 w-4" />
-						</Button>
+						{#if website}
+							<a
+								href="{website}"
+								target="_blank"
+								rel="noopener noreferrer"
+								class="max-w-xs"
+							>
+								<Button
+									class="w-full rounded-full bg-background/20 px-3 hover:bg-background/30"
+									aria-label="Go to {first_name} {last_name}'s website"
+								>
+									<Globe class="h-4 w-4" />
+								</Button>
+							</a>
+						{/if}
 					</div>
 				</div>
 			</div>

--- a/website-frontend/src/lib/components/banners/PeopleBanner.svelte
+++ b/website-frontend/src/lib/components/banners/PeopleBanner.svelte
@@ -26,13 +26,13 @@
 	};
 </script>
 
-<div>
+<div class="bg-[#343541]">
 	<div
-		class="h-[83vh] bg-cover bg-center"
+		class="h-[45vh] lg:h-[83vh] bg-cover bg-center"
 		style="background-image: linear-gradient(to top, #343541, transparent), url('{PUBLIC_APIURL}/assets/{background_image}')"
 	></div>
 
-	<div class="absolute bottom-0 w-full px-4 lg:-bottom-16 lg:px-32">
+	<div class="-mt-14 lg:absolute w-full px-4 lg:-bottom-16 lg:px-32">
 		<div class="flex space-x-2 py-4 text-sm text-secondary-foreground">
 			<p class="">Home /</p>
 			<a class="" href="/people">People /</a>
@@ -42,7 +42,7 @@
 		<div class="h-[2px] w-full bg-white opacity-40"></div>
 
 		<div
-			class="flex w-full flex-col items-center py-10 text-secondary-foreground lg:bottom-10 lg:flex-row"
+			class="flex w-full flex-col items-center pt-10 lg:py-10 text-secondary-foreground lg:bottom-10 lg:flex-row"
 		>
 			<div
 				class="mx-auto flex h-32 w-32 flex-shrink-0 items-center justify-center rounded-full bg-gradient-to-t from-[#667080] to-[#D1D8DD] md:h-48 md:w-48"

--- a/website-frontend/src/lib/components/banners/PeopleBanner.svelte
+++ b/website-frontend/src/lib/components/banners/PeopleBanner.svelte
@@ -83,7 +83,7 @@
 							>
 								{email}
 							</span>
-						</div>						
+						</div>
 
 						{#if website}
 							<a href={website} target="_blank" rel="noopener noreferrer" class="max-w-xs">

--- a/website-frontend/src/lib/components/banners/PeopleBanner.svelte
+++ b/website-frontend/src/lib/components/banners/PeopleBanner.svelte
@@ -28,11 +28,11 @@
 
 <div class="bg-[#343541]">
 	<div
-		class="h-[45vh] lg:h-[83vh] bg-cover bg-center"
+		class="h-[45vh] bg-cover bg-center lg:h-[83vh]"
 		style="background-image: linear-gradient(to top, #343541, transparent), url('{PUBLIC_APIURL}/assets/{background_image}')"
 	></div>
 
-	<div class="-mt-14 lg:absolute w-full px-4 lg:-bottom-16 lg:px-32">
+	<div class="-mt-14 w-full px-4 lg:absolute lg:-bottom-16 lg:px-32">
 		<div class="flex space-x-2 py-4 text-sm text-secondary-foreground">
 			<p class="">Home /</p>
 			<a class="" href="/people">People /</a>
@@ -42,7 +42,7 @@
 		<div class="h-[2px] w-full bg-white opacity-40"></div>
 
 		<div
-			class="flex w-full flex-col items-center pt-10 lg:py-10 text-secondary-foreground lg:bottom-10 lg:flex-row"
+			class="flex w-full flex-col items-center pt-10 text-secondary-foreground lg:bottom-10 lg:flex-row lg:py-10"
 		>
 			<div
 				class="mx-auto flex h-32 w-32 flex-shrink-0 items-center justify-center rounded-full bg-gradient-to-t from-[#667080] to-[#D1D8DD] md:h-48 md:w-48"
@@ -96,12 +96,7 @@
 						</div>
 
 						{#if website}
-							<a
-								href="{website}"
-								target="_blank"
-								rel="noopener noreferrer"
-								class="max-w-xs"
-							>
+							<a href={website} target="_blank" rel="noopener noreferrer" class="max-w-xs">
 								<Button
 									class="w-full rounded-full bg-background/20 px-3 hover:bg-background/30"
 									aria-label="Go to {first_name} {last_name}'s website"

--- a/website-frontend/src/lib/components/cards/PeopleCard.svelte
+++ b/website-frontend/src/lib/components/cards/PeopleCard.svelte
@@ -6,11 +6,11 @@
 	export let laboratory: string;
 </script>
 
-<div class="card relative flex h-full flex-col overflow-hidden md:h-[380px]">
-	<div class="inset-0 h-24 rounded-t-lg bg-gray-300 md:h-40">
+<div class="card relative flex h-full flex-col overflow-hidden w-full group">
+	<div class="inset-0 h-28 rounded-t-lg bg-gray-300 md:h-44 overflow-hidden">
 		{#if person.background_image}
 			<img
-				class="h-full w-full rounded-t-lg object-cover"
+				class="h-full w-full rounded-t-lg object-cover transition-transform duration-300 ease-out group-hover:scale-105"
 				src="{PUBLIC_APIURL}/assets/{person.background_image}"
 				alt="Background"
 			/>
@@ -18,9 +18,10 @@
 	</div>
 
 	<div class="z-10 -mt-16 items-center px-3 md:-mt-20">
-		<div
-			class="mx-auto flex h-28 w-28 items-center justify-center rounded-full border-4 border-gray-200 bg-gray-100 md:h-32 md:w-32"
-		>
+		<div class="relative mx-auto flex h-28 w-28 items-center justify-center rounded-full md:h-32 md:w-32">
+			
+			<div class="absolute -inset-[2px] md:-inset-1 -z-10 rounded-full border-2 md:border-4 border-primary/20 backdrop-blur-lg"></div>
+		
 			{#if person.profile_image}
 				<img
 					class="h-full w-full rounded-full object-cover"
@@ -32,16 +33,16 @@
 			{/if}
 		</div>
 
-		<div class="p-3 text-center md:mb-3 md:mt-2">
-			<div class="text-xs font-semibold uppercase leading-tight text-gray-500">
+		<div class="p-3 mt-2 mb-3 text-center">
+			<div class="text-xs font-semibold uppercase leading-none md:leading-tight opacity-55">
 				<p>{person.position}</p>
 			</div>
-			<h3 class="pb-2 font-bold leading-tight text-gray-900 md:py-1 md:text-xl">
+			<h3 class="py-2 font-bold leading-none text-gray-900 md:text-xl">
 				{person.first_name}
 				{person.last_name}
 			</h3>
 			{#if laboratory}
-				<div class="flex items-center justify-center text-xs text-gray-500 md:px-6">
+				<div class="text-xs font-medium leading-none md:leading-tight opacity-55 md:px-6">
 					<p class="line-clamp-2 w-full">{laboratory}</p>
 				</div>
 			{/if}

--- a/website-frontend/src/lib/components/cards/PeopleCard.svelte
+++ b/website-frontend/src/lib/components/cards/PeopleCard.svelte
@@ -6,8 +6,8 @@
 	export let laboratory: string;
 </script>
 
-<div class="card relative flex h-full flex-col overflow-hidden w-full group">
-	<div class="inset-0 h-28 rounded-t-lg bg-gray-300 md:h-44 overflow-hidden">
+<div class="card group relative flex h-full w-full flex-col overflow-hidden">
+	<div class="inset-0 h-28 overflow-hidden rounded-t-lg bg-gray-300 md:h-44">
 		{#if person.background_image}
 			<img
 				class="h-full w-full rounded-t-lg object-cover transition-transform duration-300 ease-out group-hover:scale-105"
@@ -18,10 +18,13 @@
 	</div>
 
 	<div class="z-10 -mt-16 items-center px-3 md:-mt-20">
-		<div class="relative mx-auto flex h-28 w-28 items-center justify-center rounded-full md:h-32 md:w-32">
-			
-			<div class="absolute -inset-[2px] md:-inset-1 -z-10 rounded-full border-2 md:border-4 border-primary/20 backdrop-blur-lg"></div>
-		
+		<div
+			class="relative mx-auto flex h-28 w-28 items-center justify-center rounded-full md:h-32 md:w-32"
+		>
+			<div
+				class="absolute -inset-[2px] -z-10 rounded-full border-2 border-primary/20 backdrop-blur-lg md:-inset-1 md:border-4"
+			></div>
+
 			{#if person.profile_image}
 				<img
 					class="h-full w-full rounded-full object-cover"
@@ -33,8 +36,8 @@
 			{/if}
 		</div>
 
-		<div class="p-3 mt-2 mb-3 text-center">
-			<div class="text-xs font-semibold uppercase leading-none md:leading-tight opacity-55">
+		<div class="mb-3 mt-2 p-3 text-center">
+			<div class="text-xs font-semibold uppercase leading-none opacity-55 md:leading-tight">
 				<p>{person.position}</p>
 			</div>
 			<h3 class="py-2 font-bold leading-none text-gray-900 md:text-xl">
@@ -42,7 +45,7 @@
 				{person.last_name}
 			</h3>
 			{#if laboratory}
-				<div class="text-xs font-medium leading-none md:leading-tight opacity-55 md:px-6">
+				<div class="text-xs font-medium leading-none opacity-55 md:px-6 md:leading-tight">
 					<p class="line-clamp-2 w-full">{laboratory}</p>
 				</div>
 			{/if}

--- a/website-frontend/src/lib/components/cards/PeopleCard.svelte
+++ b/website-frontend/src/lib/components/cards/PeopleCard.svelte
@@ -7,7 +7,7 @@
 </script>
 
 <div class="card group relative flex h-full w-full flex-col overflow-hidden">
-	<div class="inset-0 h-28 overflow-hidden rounded-t-lg bg-gray-300 md:h-44">
+	<div class="inset-0 h-36 overflow-hidden rounded-t-lg bg-gray-300 md:h-52">
 		{#if person.background_image}
 			<img
 				class="h-full w-full rounded-t-lg object-cover transition-transform duration-300 ease-out group-hover:scale-105"

--- a/website-frontend/src/lib/components/panel/CardPanel.svelte
+++ b/website-frontend/src/lib/components/panel/CardPanel.svelte
@@ -3,7 +3,7 @@
     max-w-[94vw] justify-center gap-2
     pb-20 md:my-8
     md:max-w-[80vw] lg:gap-3"
-	style="grid-template-columns: repeat(auto-fit, minmax(calc(var(--card-height) * (11 / 15)), auto));"
+	style="grid-template-columns: repeat(auto-fit, minmax(min(calc(var(--card-height) * (11 / 15)), 45%), 1fr));"
 >
 	<slot />
 </div>

--- a/website-frontend/src/routes/people/+page.svelte
+++ b/website-frontend/src/routes/people/+page.svelte
@@ -8,9 +8,11 @@
 
 	$: ({ people, people_overview } = data);
 
-	$: regularList = people?.filter((person: Person) => person.category === "regular-faculty") ?? [];
-	$: lecturerList = people?.filter((person: Person) => person.category === "lecturers-and-teaching-associates") ?? [];
-	$: supportList = people?.filter((person: Person) => person.category === "support-staff") ?? [];
+	$: regularList = people?.filter((person: Person) => person.category === 'regular-faculty') ?? [];
+	$: lecturerList =
+		people?.filter((person: Person) => person.category === 'lecturers-and-teaching-associates') ??
+		[];
+	$: supportList = people?.filter((person: Person) => person.category === 'support-staff') ?? [];
 
 	let heading = `text-2xl md:text-3xl font-bold inline-block pb-3 md:pb-4 leading-none`;
 </script>
@@ -24,10 +26,9 @@
 		/>
 	</div>
 
-	<div class="w-[94vw] md:w-[80vw] mx-auto">
-
+	<div class="mx-auto w-[94vw] md:w-[80vw]">
 		<div>
-			<div class="flex space-x-2 pt-5 pb-2 text-xs font-medium">
+			<div class="flex space-x-2 pb-2 pt-5 text-xs font-medium">
 				<a class="" href="/">Home</a>
 				<p class="opacity-55">/</p>
 				<p class="opacity-55">People</p>
@@ -37,7 +38,7 @@
 
 		<div class="space-y-4 py-8 md:py-10">
 			{#if regularList.length > 0}
-				<a class="{heading}" href="/people/regular-faculty">Regular Faculty</a>
+				<a class={heading} href="/people/regular-faculty">Regular Faculty</a>
 				<CardPanel>
 					{#each regularList as person}
 						<a href="/people/{person.category}/{person.username}">
@@ -47,7 +48,9 @@
 				</CardPanel>
 			{/if}
 			{#if lecturerList.length > 0}
-				<a class="{heading}" href="/people/lecturers-and-teaching-associates">Lecturers & Teaching Associates</a>
+				<a class={heading} href="/people/lecturers-and-teaching-associates"
+					>Lecturers & Teaching Associates</a
+				>
 				<CardPanel>
 					{#each lecturerList as person}
 						<a href="/people/{person.category}/{person.username}">
@@ -57,7 +60,7 @@
 				</CardPanel>
 			{/if}
 			{#if supportList.length > 0}
-				<a class="{heading}" href="/people/support-staff">Support Staff</a>
+				<a class={heading} href="/people/support-staff">Support Staff</a>
 				<CardPanel>
 					{#each supportList as person}
 						<a href="/people/{person.category}/{person.username}">

--- a/website-frontend/src/routes/people/+page.svelte
+++ b/website-frontend/src/routes/people/+page.svelte
@@ -11,6 +11,8 @@
 	$: regularList = people?.filter((person: Person) => person.category === "regular-faculty") ?? [];
 	$: lecturerList = people?.filter((person: Person) => person.category === "lecturers-and-teaching-associates") ?? [];
 	$: supportList = people?.filter((person: Person) => person.category === "support-staff") ?? [];
+
+	let heading = `text-2xl md:text-3xl font-bold inline-block pb-3 md:pb-4 leading-none`;
 </script>
 
 <body>
@@ -22,7 +24,6 @@
 		/>
 	</div>
 
- 
 	<div class="w-[94vw] md:w-[80vw] mx-auto">
 
 		<div>
@@ -36,7 +37,7 @@
 
 		<div class="space-y-4 py-8 md:py-10">
 			{#if regularList.length > 0}
-				<a class="text-2xl md:text-3xl font-bold inline-block pb-3 md:pb-4 leading-none" href="/people/regular-faculty">Regular Faculty</a>
+				<a class="{heading}" href="/people/regular-faculty">Regular Faculty</a>
 				<CardPanel>
 					{#each regularList as person}
 						<a href="/people/{person.category}/{person.username}">
@@ -46,7 +47,7 @@
 				</CardPanel>
 			{/if}
 			{#if lecturerList.length > 0}
-				<a class="text-2xl md:text-3xl font-bold inline-block pb-3 md:pb-4 leading-none" href="/people/lecturers-and-teaching-associates">Lecturers & Teaching Associates</a>
+				<a class="{heading}" href="/people/lecturers-and-teaching-associates">Lecturers & Teaching Associates</a>
 				<CardPanel>
 					{#each lecturerList as person}
 						<a href="/people/{person.category}/{person.username}">
@@ -56,7 +57,7 @@
 				</CardPanel>
 			{/if}
 			{#if supportList.length > 0}
-				<a class="text-2xl md:text-3xl font-bold inline-block pb-3 md:pb-4 leading-none" href="/people/support-staff">Support Staff</a>
+				<a class="{heading}" href="/people/support-staff">Support Staff</a>
 				<CardPanel>
 					{#each supportList as person}
 						<a href="/people/{person.category}/{person.username}">

--- a/website-frontend/src/routes/people/+page.svelte
+++ b/website-frontend/src/routes/people/+page.svelte
@@ -9,9 +9,6 @@
 
 	$: ({ people, people_overview, position_filters, laboratory_filters } = data);
 
-	const inc = 12;
-	let shown = inc;
-
 	$: controls = [
 		{
 			name: 'position',
@@ -22,8 +19,6 @@
 			categories: laboratory_filters
 		}
 	];
-
-	$: peopleList = people?.slice(0, shown);
 </script>
 
 <body>
@@ -53,16 +48,11 @@
 
 
 		<CardPanel>
-			{#each peopleList as person}
+			{#each people as person}
 				<a href="/people/{person.category}/{person.username}">
 					<PeopleCard {person} laboratory={person.affiliations?.[0]?.laboratories_id?.name} />
 				</a>
 			{/each}
-			{#if shown < people.length}
-				<div class="col-span-full mt-8 flex items-center justify-center">
-					<LoadMore {inc} bind:shown />
-				</div>
-			{/if}
 		</CardPanel>
 	</div>
 </body>

--- a/website-frontend/src/routes/people/+page.svelte
+++ b/website-frontend/src/routes/people/+page.svelte
@@ -2,13 +2,15 @@
 	/** @type {import('./$types').PageData} */
 	import Banner from '$lib/components/banners/Banner.svelte';
 	import CardPanel from '$lib/components/panel/CardPanel.svelte';
-	import FilterBar from '$lib/components/filter/FilterBar.svelte';
-	import LoadMore from '$lib/components/buttons/LoadMore.svelte';
 	import PeopleCard from '$lib/components/cards/PeopleCard.svelte';
+	import { Person } from '$lib/models/people';
 	export let data;
 
 	$: ({ people, people_overview } = data);
 
+	$: regularList = people?.filter((person: Person) => person.category === "regular-faculty") ?? [];
+	$: lecturerList = people?.filter((person: Person) => person.category === "lecturers-and-teaching-associates") ?? [];
+	$: supportList = people?.filter((person: Person) => person.category === "support-staff") ?? [];
 </script>
 
 <body>
@@ -20,8 +22,8 @@
 		/>
 	</div>
 
-
-	<div class="md:px-32">
+ 
+	<div class="w-[94vw] md:w-[80vw] mx-auto">
 
 		<div>
 			<div class="flex space-x-2 pt-5 pb-2 text-xs font-medium">
@@ -32,17 +34,37 @@
 			<div class="h-[1px] w-full bg-primary opacity-20"></div>
 		</div>
 
-		<p class="text-3xl font-bold">Regular Faculty</p>
-		<p class="text-3xl font-bold">Lecturers & Teaching Associates</p>
-		<p class="text-3xl font-bold">Support Staff</p>
-
-
-		<CardPanel>
-			{#each people as person}
-				<a href="/people/{person.category}/{person.username}">
-					<PeopleCard {person} laboratory={person.affiliations?.[0]?.laboratories_id?.name} />
-				</a>
-			{/each}
-		</CardPanel>
+		<div class="space-y-4 py-10">
+			{#if regularList.length > 0}
+				<a class="text-2xl md:text-3xl font-bold block pb-4" href="/people/regular-faculty">Regular Faculty</a>
+				<CardPanel>
+					{#each regularList as person}
+						<a href="/people/{person.category}/{person.username}">
+							<PeopleCard {person} laboratory={person.affiliations?.[0]?.laboratories_id?.name} />
+						</a>
+					{/each}
+				</CardPanel>
+			{/if}
+			{#if lecturerList.length > 0}
+				<a class="text-2xl md:text-3xl font-bold block pb-4" href="/people/lecturers-and-teaching-associates">Lecturers & Teaching Associates</a>
+				<CardPanel>
+					{#each lecturerList as person}
+						<a href="/people/{person.category}/{person.username}">
+							<PeopleCard {person} laboratory={person.affiliations?.[0]?.laboratories_id?.name} />
+						</a>
+					{/each}
+				</CardPanel>
+			{/if}
+			{#if supportList.length > 0}
+				<a class="text-2xl md:text-3xl font-bold block pb-4" href="/people/support-staff">Support Staff</a>
+				<CardPanel>
+					{#each supportList as person}
+						<a href="/people/{person.category}/{person.username}">
+							<PeopleCard {person} laboratory={person.affiliations?.[0]?.laboratories_id?.name} />
+						</a>
+					{/each}
+				</CardPanel>
+			{/if}
+		</div>
 	</div>
 </body>

--- a/website-frontend/src/routes/people/+page.svelte
+++ b/website-frontend/src/routes/people/+page.svelte
@@ -36,7 +36,7 @@
 
 		<div class="space-y-4 py-8 md:py-10">
 			{#if regularList.length > 0}
-				<a class="text-2xl md:text-3xl font-bold block pb-3 md:pb-4 leading-none" href="/people/regular-faculty">Regular Faculty</a>
+				<a class="text-2xl md:text-3xl font-bold inline-block pb-3 md:pb-4 leading-none" href="/people/regular-faculty">Regular Faculty</a>
 				<CardPanel>
 					{#each regularList as person}
 						<a href="/people/{person.category}/{person.username}">
@@ -46,7 +46,7 @@
 				</CardPanel>
 			{/if}
 			{#if lecturerList.length > 0}
-				<a class="text-2xl md:text-3xl font-bold block pb-3 md:pb-4 leading-none" href="/people/lecturers-and-teaching-associates">Lecturers & Teaching Associates</a>
+				<a class="text-2xl md:text-3xl font-bold inline-block pb-3 md:pb-4 leading-none" href="/people/lecturers-and-teaching-associates">Lecturers & Teaching Associates</a>
 				<CardPanel>
 					{#each lecturerList as person}
 						<a href="/people/{person.category}/{person.username}">
@@ -56,7 +56,7 @@
 				</CardPanel>
 			{/if}
 			{#if supportList.length > 0}
-				<a class="text-2xl md:text-3xl font-bold block pb-3 md:pb-4 leading-none" href="/people/support-staff">Support Staff</a>
+				<a class="text-2xl md:text-3xl font-bold inline-block pb-3 md:pb-4 leading-none" href="/people/support-staff">Support Staff</a>
 				<CardPanel>
 					{#each supportList as person}
 						<a href="/people/{person.category}/{person.username}">

--- a/website-frontend/src/routes/people/+page.svelte
+++ b/website-frontend/src/routes/people/+page.svelte
@@ -7,18 +7,8 @@
 	import PeopleCard from '$lib/components/cards/PeopleCard.svelte';
 	export let data;
 
-	$: ({ people, people_overview, position_filters, laboratory_filters } = data);
+	$: ({ people, people_overview } = data);
 
-	$: controls = [
-		{
-			name: 'position',
-			categories: position_filters
-		},
-		{
-			name: 'laboratory',
-			categories: laboratory_filters
-		}
-	];
 </script>
 
 <body>

--- a/website-frontend/src/routes/people/+page.svelte
+++ b/website-frontend/src/routes/people/+page.svelte
@@ -34,9 +34,9 @@
 			<div class="h-[1px] w-full bg-primary opacity-20"></div>
 		</div>
 
-		<div class="space-y-4 py-10">
+		<div class="space-y-4 py-8 md:py-10">
 			{#if regularList.length > 0}
-				<a class="text-2xl md:text-3xl font-bold block pb-4" href="/people/regular-faculty">Regular Faculty</a>
+				<a class="text-2xl md:text-3xl font-bold block pb-3 md:pb-4 leading-none" href="/people/regular-faculty">Regular Faculty</a>
 				<CardPanel>
 					{#each regularList as person}
 						<a href="/people/{person.category}/{person.username}">
@@ -46,7 +46,7 @@
 				</CardPanel>
 			{/if}
 			{#if lecturerList.length > 0}
-				<a class="text-2xl md:text-3xl font-bold block pb-4" href="/people/lecturers-and-teaching-associates">Lecturers & Teaching Associates</a>
+				<a class="text-2xl md:text-3xl font-bold block pb-3 md:pb-4 leading-none" href="/people/lecturers-and-teaching-associates">Lecturers & Teaching Associates</a>
 				<CardPanel>
 					{#each lecturerList as person}
 						<a href="/people/{person.category}/{person.username}">
@@ -56,7 +56,7 @@
 				</CardPanel>
 			{/if}
 			{#if supportList.length > 0}
-				<a class="text-2xl md:text-3xl font-bold block pb-4" href="/people/support-staff">Support Staff</a>
+				<a class="text-2xl md:text-3xl font-bold block pb-3 md:pb-4 leading-none" href="/people/support-staff">Support Staff</a>
 				<CardPanel>
 					{#each supportList as person}
 						<a href="/people/{person.category}/{person.username}">

--- a/website-frontend/src/routes/people/+page.svelte
+++ b/website-frontend/src/routes/people/+page.svelte
@@ -35,19 +35,34 @@
 		/>
 	</div>
 
-	<div class="relative z-10 -mt-7">
-		<FilterBar {controls} />
-	</div>
-	<CardPanel>
-		{#each peopleList as person}
-			<a href="/people/{person.category}/{person.username}">
-				<PeopleCard {person} laboratory={person.affiliations?.[0]?.laboratories_id?.name} />
-			</a>
-		{/each}
-		{#if shown < people.length}
-			<div class="col-span-full mt-8 flex items-center justify-center">
-				<LoadMore {inc} bind:shown />
+
+	<div class="md:px-32">
+
+		<div>
+			<div class="flex space-x-2 pt-5 pb-2 text-xs font-medium">
+				<a class="" href="/">Home</a>
+				<p class="opacity-55">/</p>
+				<p class="opacity-55">People</p>
 			</div>
-		{/if}
-	</CardPanel>
+			<div class="h-[1px] w-full bg-primary opacity-20"></div>
+		</div>
+
+		<p class="text-3xl font-bold">Regular Faculty</p>
+		<p class="text-3xl font-bold">Lecturers & Teaching Associates</p>
+		<p class="text-3xl font-bold">Support Staff</p>
+
+
+		<CardPanel>
+			{#each peopleList as person}
+				<a href="/people/{person.category}/{person.username}">
+					<PeopleCard {person} laboratory={person.affiliations?.[0]?.laboratories_id?.name} />
+				</a>
+			{/each}
+			{#if shown < people.length}
+				<div class="col-span-full mt-8 flex items-center justify-center">
+					<LoadMore {inc} bind:shown />
+				</div>
+			{/if}
+		</CardPanel>
+	</div>
 </body>

--- a/website-frontend/src/routes/people/[slug]/+page.svelte
+++ b/website-frontend/src/routes/people/[slug]/+page.svelte
@@ -20,9 +20,9 @@
 			/>
 		</div>
 
-		<div class="w-[94vw] md:w-[80vw] mx-auto">
+		<div class="mx-auto w-[94vw] md:w-[80vw]">
 			<div>
-				<div class="flex space-x-2 pt-5 pb-2 text-xs font-medium">
+				<div class="flex space-x-2 pb-2 pt-5 text-xs font-medium">
 					<a class="" href="/">Home</a>
 					<p class="opacity-55">/</p>
 					<a class="" href="/people">People</a>
@@ -31,7 +31,7 @@
 				</div>
 				<div class="h-[1px] w-full bg-primary opacity-20"></div>
 			</div>
-		
+
 			<CardPanel>
 				{#each people as person}
 					<a href="/people/{category.title}/{person.username}">

--- a/website-frontend/src/routes/people/[slug]/+page.svelte
+++ b/website-frontend/src/routes/people/[slug]/+page.svelte
@@ -2,28 +2,12 @@
 	/** @type {import('./$types').PageData} */
 	import Banner from '$lib/components/banners/Banner.svelte';
 	import CardPanel from '$lib/components/panel/CardPanel.svelte';
-	import FilterBar from '$lib/components/filter/FilterBar.svelte';
-	import LoadMore from '$lib/components/buttons/LoadMore.svelte';
 	import PeopleCard from '$lib/components/cards/PeopleCard.svelte';
+	import { deslugify } from '$lib/utils';
 
 	export let data;
 
-	$: ({ category, people, position_filters, laboratory_filters } = data);
-
-	const inc = 12;
-	let shown = inc;
-	$: peopleList = people?.slice(0, shown);
-
-	$: controls = [
-		{
-			name: 'position',
-			categories: position_filters
-		},
-		{
-			name: 'laboratory',
-			categories: laboratory_filters
-		}
-	];
+	$: ({ category, people } = data);
 </script>
 
 <body>
@@ -36,22 +20,26 @@
 			/>
 		</div>
 
-		<div class="relative z-10 -mt-7">
-			<FilterBar {controls} />
-		</div>
-
-		<CardPanel>
-			{#each peopleList as person}
-				<a href="/people/{category.title}/{person.username}">
-					<PeopleCard {person} laboratory={person.affiliations?.[0]?.laboratories_id?.name} />
-				</a>
-			{/each}
-			{#if shown < people.length}
-				<div class="col-span-full mt-8 flex items-center justify-center">
-					<LoadMore {inc} bind:shown />
+		<div class="w-[94vw] md:w-[80vw] mx-auto">
+			<div>
+				<div class="flex space-x-2 pt-5 pb-2 text-xs font-medium">
+					<a class="" href="/">Home</a>
+					<p class="opacity-55">/</p>
+					<a class="" href="/people">People</a>
+					<p class="opacity-55">/</p>
+					<p class="opacity-55">{deslugify(category.title)}</p>
 				</div>
-			{/if}
-		</CardPanel>
+				<div class="h-[1px] w-full bg-primary opacity-20"></div>
+			</div>
+		
+			<CardPanel>
+				{#each people as person}
+					<a href="/people/{category.title}/{person.username}">
+						<PeopleCard {person} laboratory={person.affiliations?.[0]?.laboratories_id?.name} />
+					</a>
+				{/each}
+			</CardPanel>
+		</div>
 	{:else}
 		<p>People category not found</p>
 	{/if}

--- a/website-frontend/src/routes/people/[slug]/[username]/+page.svelte
+++ b/website-frontend/src/routes/people/[slug]/[username]/+page.svelte
@@ -35,24 +35,24 @@
 		/>
 	</div>
 
-	<div class="bg-[#343541] -mt-[1px]">
+	<div class="-mt-[1px] bg-[#343541]">
 		<div
 			class="space-y-9 px-4 pb-16 pt-9 md:max-w-6xl md:space-y-12 md:px-10 md:pb-24 md:pt-12 lg:pl-[369px]"
 		>
 			<div class="text-lg leading-normal text-primary-foreground">
 				{#if person.educational_attainment}
 					<ul class="list-disc pl-5 text-primary-foreground">
-					{#each person.educational_attainment as education}
-						<li>
-							{education.degree} from {education.institution}
-							{education.start_date ? ` (${new Date(education.start_date).getFullYear()}` : ''}
-							{education.end_date
-								? ` - ${new Date(education.end_date).getFullYear()})`
-								: education.start_date
-									? ')'
-									: ''}
-						</li>
-					{/each}
+						{#each person.educational_attainment as education}
+							<li>
+								{education.degree} from {education.institution}
+								{education.start_date ? ` (${new Date(education.start_date).getFullYear()}` : ''}
+								{education.end_date
+									? ` - ${new Date(education.end_date).getFullYear()})`
+									: education.start_date
+										? ')'
+										: ''}
+							</li>
+						{/each}
 					</ul>
 				{/if}
 			</div>

--- a/website-frontend/src/routes/people/[slug]/[username]/+page.svelte
+++ b/website-frontend/src/routes/people/[slug]/[username]/+page.svelte
@@ -45,7 +45,9 @@
 						{#each person.educational_attainment as education}
 							<li>
 								{education.degree} from {education.institution}
-								{education.start_date ? ` (${new Date(education.start_date).toLocaleDateString('en-US', { month: 'long', year: 'numeric' })}` : ''}
+								{education.start_date
+									? ` (${new Date(education.start_date).toLocaleDateString('en-US', { month: 'long', year: 'numeric' })}`
+									: ''}
 								{education.end_date
 									? ` - ${new Date(education.end_date).toLocaleDateString('en-US', { month: 'long', year: 'numeric' })})`
 									: education.start_date

--- a/website-frontend/src/routes/people/[slug]/[username]/+page.svelte
+++ b/website-frontend/src/routes/people/[slug]/[username]/+page.svelte
@@ -45,11 +45,11 @@
 						{#each person.educational_attainment as education}
 							<li>
 								{education.degree} from {education.institution}
-								{education.start_date ? ` (${new Date(education.start_date).getFullYear()}` : ''}
+								{education.start_date ? ` (${new Date(education.start_date).toLocaleDateString('en-US', { month: 'long', year: 'numeric' })}` : ''}
 								{education.end_date
-									? ` - ${new Date(education.end_date).getFullYear()})`
+									? ` - ${new Date(education.end_date).toLocaleDateString('en-US', { month: 'long', year: 'numeric' })})`
 									: education.start_date
-										? ')'
+										? '- present)'
 										: ''}
 							</li>
 						{/each}

--- a/website-frontend/src/routes/people/[slug]/[username]/+page.svelte
+++ b/website-frontend/src/routes/people/[slug]/[username]/+page.svelte
@@ -35,14 +35,15 @@
 		/>
 	</div>
 
-	<div class="bg-[#343541]">
+	<div class="bg-[#343541] -mt-[1px]">
 		<div
 			class="space-y-9 px-4 pb-16 pt-9 md:max-w-6xl md:space-y-12 md:px-10 md:pb-24 md:pt-12 lg:pl-[369px]"
 		>
 			<div class="text-lg leading-normal text-primary-foreground">
 				{#if person.educational_attainment}
+					<ul class="list-disc pl-5 text-primary-foreground">
 					{#each person.educational_attainment as education}
-						<p>
+						<li>
 							{education.degree} from {education.institution}
 							{education.start_date ? ` (${new Date(education.start_date).getFullYear()}` : ''}
 							{education.end_date
@@ -50,8 +51,9 @@
 								: education.start_date
 									? ')'
 									: ''}
-						</p>
+						</li>
 					{/each}
+					</ul>
 				{/if}
 			</div>
 

--- a/website-frontend/src/routes/people/[slug]/[username]/+page.svelte
+++ b/website-frontend/src/routes/people/[slug]/[username]/+page.svelte
@@ -59,7 +59,9 @@
 				{/if}
 			</div>
 
-			<InfoCard office={person.location ?? ''} interests={person.interests ?? ''} />
+			{#if person.location || person.interests}
+				<InfoCard office={person.location ?? ''} interests={person.interests ?? ''} />
+			{/if}
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
This PR introduces several improvements to the People pages:  

- **Breadcrumbs:** Added to the People subpages for better navigation. *(Note: it is not yet responsive.)*  
- **UI Enhancements:**  
  - Adjusted the PeopleCard layout.  
  - Improved the mobile People details page.  
- **Aggregation:** Added headings & aggregation in the main People page for better organization.  
- **Conditional Website Button:** The website button is now hidden when unavailable in the People details page.  

Additionally:
- **CardPanel Update:** Ensures a minimum of **two columns**, even on smaller screens.  