### PR TITLE
fix: solve error page issues

### DIFF
--- a/website-frontend/src/routes/+error.svelte
+++ b/website-frontend/src/routes/+error.svelte
@@ -3,7 +3,7 @@
 </script>
 
 <div class="container prose mt-20 flex flex-col items-center">
-	<h1>{page.status}: {page.error?.message}</h1>
+	<h1>{$page.status}: {$page.error?.message}</h1>
 
 	<aside>
 		<blockquote>


### PR DESCRIPTION
This PR fixes a naming issue in accessing the `page` store on the error page.

- feat: change adapter to adapter-node
- feat: designate pnpm as package manager
- feat: remove package manager key in package.json
- fix: use $app/stores instead of $app/state
- fix: fix page store access in error page
