### PR TITLE
feat: load academics subcollections for subpages

### DIFF
--- a/website-frontend/src/routes/academics/+page.server.ts
+++ b/website-frontend/src/routes/academics/+page.server.ts
@@ -7,7 +7,7 @@ export async function load({ fetch }) {
 	const academics = await directus.request(readSingleton('academics'));
 	const academics_categories = await directus.request(
 		readItems('academics_categories', {
-			fields: ['name', 'slug']
+			fields: ['name', 'slug', 'description']
 		})
 	);
 	const academics_programs = await directus.request(

--- a/website-frontend/src/routes/academics/+page.server.ts
+++ b/website-frontend/src/routes/academics/+page.server.ts
@@ -5,6 +5,11 @@ import { readItems, readSingleton } from '@directus/sdk';
 export async function load({ fetch }) {
 	const directus = getDirectusInstance(fetch);
 	const academics = await directus.request(readSingleton('academics'));
+	const academics_categories = await directus.request(
+		readItems('academics_categories', {
+			fields: ['name', 'slug']
+		})
+	);
 	const academics_programs = await directus.request(
 		readItems('academics_programs', {
 			fields: [
@@ -22,5 +27,5 @@ export async function load({ fetch }) {
 		})
 	);
 
-	return { academics, academics_programs, academics_courses };
+	return { academics, academics_categories, academics_programs, academics_courses };
 }

--- a/website-frontend/src/routes/academics/+page.svelte
+++ b/website-frontend/src/routes/academics/+page.svelte
@@ -5,6 +5,7 @@
 	import FlexibleContent from '$lib/components/flexible_content/FlexibleContent.svelte';
 	import CoursesTable from '$lib/components/table/CoursesTable.svelte';
 	import Breadcrumb from '$lib/components/breadcrumbs/PageBreadcrumb.svelte';
+	import HorizontalCard from '$lib/components/cards/HorizontalCard.svelte';
 
 	export let data;
 	$: ({ academics, academics_categories, academics_courses } = data);
@@ -34,9 +35,14 @@
 							Programs offered by the department
 						</h1>
 						{#if academics_categories}
-							<div class="space-y-1">
+							<div class="space-y-3">
 								{#each academics_categories as acad_category}
-									<LinkButton text={acad_category.name} link="academics/{acad_category.slug}" />
+									<a href="academics/{acad_category.slug}" class="block">
+										<HorizontalCard
+											name={acad_category.name}
+											description={acad_category.description ?? undefined}
+										/>
+									</a>
 								{/each}
 							</div>
 						{/if}

--- a/website-frontend/src/routes/academics/+page.svelte
+++ b/website-frontend/src/routes/academics/+page.svelte
@@ -1,7 +1,6 @@
 <script>
 	/** @type {import('./$types').PageData} */
 	import Banner from '$lib/components/banners/Banner.svelte';
-	import LinkButton from '$lib/components/buttons/LinkButton.svelte';
 	import FlexibleContent from '$lib/components/flexible_content/FlexibleContent.svelte';
 	import CoursesTable from '$lib/components/table/CoursesTable.svelte';
 	import Breadcrumb from '$lib/components/breadcrumbs/PageBreadcrumb.svelte';

--- a/website-frontend/src/routes/academics/+page.svelte
+++ b/website-frontend/src/routes/academics/+page.svelte
@@ -7,7 +7,7 @@
 	import Breadcrumb from '$lib/components/breadcrumbs/PageBreadcrumb.svelte';
 
 	export let data;
-	$: ({ academics, academics_courses } = data);
+	$: ({ academics, academics_categories, academics_courses } = data);
 </script>
 
 <body>
@@ -33,10 +33,13 @@
 						<h1 class="mb-3 text-2xl font-bold leading-tight md:mb-6 md:text-3xl">
 							Programs offered by the department
 						</h1>
-						<div class="space-y-1">
-							<LinkButton text="Undergraduate Page" link="academics/undergraduate" />
-							<LinkButton text="Graduate Page" link="academics/graduate" />
-						</div>
+						{#if academics_categories}
+							<div class="space-y-1">
+								{#each academics_categories as acad_category}
+									<LinkButton text={acad_category.name} link="academics/{acad_category.slug}" />
+								{/each}
+							</div>
+						{/if}
 					</div>
 
 					<div>

--- a/website-frontend/src/routes/academics/[category]/+page.server.ts
+++ b/website-frontend/src/routes/academics/[category]/+page.server.ts
@@ -42,23 +42,6 @@ export async function load({ fetch, params }) {
 		})
 	);
 
-	const academics_courses = await directus.request(
-		readItems('academics_courses', {
-			sort: ['course_code'],
-			filter: {
-				related_academics_programs: {
-					academics_programs_id: {
-						category: {
-							slug: {
-								_eq: params.category
-							}
-						}
-					}
-				}
-			}
-		})
-	);
-
 	const academics_pages = await directus.request(
 		readItems('academics_pages', {
 			fields: ['title', 'slug'],
@@ -72,5 +55,5 @@ export async function load({ fetch, params }) {
 		})
 	);
 
-	return { academics_category, academics_programs, academics_courses, academics_pages };
+	return { academics_category, academics_programs, academics_pages };
 }

--- a/website-frontend/src/routes/academics/[category]/+page.server.ts
+++ b/website-frontend/src/routes/academics/[category]/+page.server.ts
@@ -59,5 +59,18 @@ export async function load({ fetch, params }) {
 		})
 	);
 
-	return { academics_category, academics_programs, academics_courses };
+	const academics_pages = await directus.request(
+		readItems('academics_pages', {
+			fields: ['title', 'slug'],
+			filter: {
+				category: {
+					slug: {
+						_eq: params.category
+					}
+				}
+			}
+		})
+	);
+
+	return { academics_category, academics_programs, academics_courses, academics_pages };
 }

--- a/website-frontend/src/routes/academics/[category]/+page.svelte
+++ b/website-frontend/src/routes/academics/[category]/+page.svelte
@@ -7,7 +7,7 @@
 	import Breadcrumb from '$lib/components/breadcrumbs/PageBreadcrumb.svelte';
 
 	export let data;
-	$: ({ academics_category, academics_programs } = data);
+	$: ({ academics_category, academics_programs, academics_pages } = data);
 </script>
 
 <body>
@@ -51,15 +51,11 @@
 								text="{academics_category.name} Courses"
 								link="{academics_category.slug}/courses"
 							/>
-							<LinkButton
-								text="Admission Procedure"
-								link="{academics_category.slug}/admission-procedure"
-							/>
-							<LinkButton
-								text="Academic Processes & Rules"
-								link="{academics_category.slug}/academic-processes-and-rules"
-							/>
-							<LinkButton text="Forms" link="{academics_category.slug}/forms" />
+							{#if academics_pages}
+								{#each academics_pages as page}
+									<LinkButton text={page.title} link="{academics_category.slug}/{page.slug}" />
+								{/each}
+							{/if}
 						</div>
 					</div>
 				</div>


### PR DESCRIPTION
This pull request to the `website-frontend` project includes updating the server-side load functions to fetch new data, modifying the Svelte components to use the fetched data, and replacing static links with dynamically generated ones.

Enhancements to data fetching:

* Added a request to fetch `academics_categories` and included it in the returned data.
* Replaced the request for `academics_courses` with a request for `academics_pages` and included it in the returned data.
* Added `HorizontalCard` component, updated the reactive statement to include `academics_categories`, and replaced static links with dynamically generated cards for each academic category.
* Updated the reactive statement to include `academics_pages` and replaced static links with dynamically generated links for each academic page.