### PR TITLE
feat: add division by rank in people pages

### DIFF
--- a/website-frontend/src/app.postcss
+++ b/website-frontend/src/app.postcss
@@ -65,7 +65,7 @@
 	}
 
 	.content-padding {
-		@apply max-w-6xl space-y-16 pb-16 md:space-y-24 md:pb-24;
+		@apply w-full max-w-6xl space-y-16 pb-16 md:space-y-24 md:pb-24;
 	}
 
 	.heading-padding {

--- a/website-frontend/src/lib/components/panel/CardPanel.svelte
+++ b/website-frontend/src/lib/components/panel/CardPanel.svelte
@@ -5,7 +5,7 @@
 <div
 	class="mx-auto my-3 grid
     max-w-[94vw] justify-center gap-2
-    pb-20 md:my-8
+    md:my-8
     md:max-w-[80vw] lg:gap-3"
 	style="grid-template-columns: repeat(auto-fit, {width}px);"
 >

--- a/website-frontend/src/routes/people/+page.svelte
+++ b/website-frontend/src/routes/people/+page.svelte
@@ -9,62 +9,40 @@
 
 	$: ({ people, people_overview } = data);
 
-	$: regularList = people?.filter((person: Person) => person.category === 'regular-faculty') ?? [];
-	$: lecturerList =
-		people?.filter((person: Person) => person.category === 'lecturers-and-teaching-associates') ??
-		[];
-	$: supportList = people?.filter((person: Person) => person.category === 'support-staff') ?? [];
-
-	let heading = `text-2xl md:text-3xl font-bold inline-block pb-3 md:pb-4 leading-none`;
+	$: positions = Array.from(new Set(people.map((person: Person) => person.position).filter(Boolean)));
+	$: peopleByPosition = positions.map((position) => ({
+	    position,
+	    people: people.filter((person: Person) => person.position === position)
+	}));
 </script>
 
 <body>
-	<div class="relative z-0">
-		<Banner
-			title="People"
-			background_image={people_overview.background_image ?? ''}
-			flexible_content={people_overview.flexible_content}
-		/>
-	</div>
+	<Banner
+		title="People"
+		background_image={people_overview.background_image ?? ''}
+		flexible_content={people_overview.flexible_content}
+	/>
 
-	<div class="mx-auto w-[94vw] md:w-[80vw]">
-		<div class="mt-5">
-			<Breadcrumb />
-		</div>
+	<div class="flex justify-center px-4">
+		<div class="content-padding">
 
-		<div class="space-y-4 py-8 md:py-10">
-			{#if regularList.length > 0}
-				<a class={heading} href="/people/regular-faculty">Regular Faculty</a>
-				<CardPanel>
-					{#each regularList as person}
-						<a href="/people/{person.category}/{person.username}">
-							<PeopleCard {person} laboratory={person.affiliations?.[0]?.laboratories_id?.name} />
-						</a>
-					{/each}
-				</CardPanel>
-			{/if}
-			{#if lecturerList.length > 0}
-				<a class={heading} href="/people/lecturers-and-teaching-associates"
-					>Lecturers & Teaching Associates</a
-				>
-				<CardPanel>
-					{#each lecturerList as person}
-						<a href="/people/{person.category}/{person.username}">
-							<PeopleCard {person} laboratory={person.affiliations?.[0]?.laboratories_id?.name} />
-						</a>
-					{/each}
-				</CardPanel>
-			{/if}
-			{#if supportList.length > 0}
-				<a class={heading} href="/people/support-staff">Support Staff</a>
-				<CardPanel>
-					{#each supportList as person}
-						<a href="/people/{person.category}/{person.username}">
-							<PeopleCard {person} laboratory={person.affiliations?.[0]?.laboratories_id?.name} />
-						</a>
-					{/each}
-				</CardPanel>
-			{/if}
+			<div class="pt-5">
+				<Breadcrumb />
+			</div>
+
+			{#each peopleByPosition as { position, people } }
+				<div>
+					<p class="heading-text">{position}s</p>
+					<CardPanel>
+						{#each people as person (person.username)}
+							<a href="/people/{person.category}/{person.username}">
+								<PeopleCard {person} laboratory={person.affiliations?.[0]?.laboratories_id?.name} />
+							</a>
+						{/each}
+					</CardPanel>
+				</div>
+			{/each}
+
 		</div>
 	</div>
 </body>

--- a/website-frontend/src/routes/people/+page.svelte
+++ b/website-frontend/src/routes/people/+page.svelte
@@ -9,10 +9,12 @@
 
 	$: ({ people, people_overview } = data);
 
-	$: positions = Array.from(new Set(people.map((person: Person) => person.position).filter(Boolean)));
+	$: positions = Array.from(
+		new Set(people.map((person: Person) => person.position).filter(Boolean))
+	);
 	$: peopleByPosition = positions.map((position) => ({
-	    position,
-	    people: people.filter((person: Person) => person.position === position)
+		position,
+		people: people.filter((person: Person) => person.position === position)
 	}));
 </script>
 
@@ -25,12 +27,11 @@
 
 	<div class="flex justify-center px-4">
 		<div class="content-padding">
-
 			<div class="pt-5">
 				<Breadcrumb />
 			</div>
 
-			{#each peopleByPosition as { position, people } }
+			{#each peopleByPosition as { position, people }}
 				<div>
 					<p class="heading-text">{position}s</p>
 					<CardPanel>
@@ -42,7 +43,6 @@
 					</CardPanel>
 				</div>
 			{/each}
-
 		</div>
 	</div>
 </body>

--- a/website-frontend/src/routes/people/+page.svelte
+++ b/website-frontend/src/routes/people/+page.svelte
@@ -9,9 +9,33 @@
 
 	$: ({ people, people_overview } = data);
 
+	const priority = [
+	    "Professor", 
+	    "Associate Professor", 
+	    "Assistant Professor", 
+	    "Instructor", 
+	    "Lecturer", 
+	    "Researcher"
+	];
+
 	$: positions = Array.from(
-		new Set(people.map((person: Person) => person.position).filter(Boolean))
-	);
+	    new Set(people.map((person: Person) => person.position).filter(Boolean))
+	).map(pos => pos as string).sort((a, b) => {
+	    const indexA = priority.indexOf(a);
+	    const indexB = priority.indexOf(b);
+
+	    // If both positions are in the priority list, sort by their order
+	    if (indexA !== -1 && indexB !== -1) {
+	        return indexA - indexB;
+	    }
+	    // If only one is in the priority list, prioritize it
+	    if (indexA !== -1) return -1;
+	    if (indexB !== -1) return 1;
+
+	    // Otherwise, sort alphabetically
+	    return a.localeCompare(b);
+	});
+
 	$: peopleByPosition = positions.map((position) => ({
 		position,
 		people: people.filter((person: Person) => person.position === position)

--- a/website-frontend/src/routes/people/+page.svelte
+++ b/website-frontend/src/routes/people/+page.svelte
@@ -10,31 +10,33 @@
 	$: ({ people, people_overview } = data);
 
 	const priority = [
-	    "Professor", 
-	    "Associate Professor", 
-	    "Assistant Professor", 
-	    "Instructor", 
-	    "Lecturer", 
-	    "Researcher"
+		'Professor',
+		'Associate Professor',
+		'Assistant Professor',
+		'Instructor',
+		'Lecturer',
+		'Researcher'
 	];
 
 	$: positions = Array.from(
-	    new Set(people.map((person: Person) => person.position).filter(Boolean))
-	).map(pos => pos as string).sort((a, b) => {
-	    const indexA = priority.indexOf(a);
-	    const indexB = priority.indexOf(b);
+		new Set(people.map((person: Person) => person.position).filter(Boolean))
+	)
+		.map((pos) => pos as string)
+		.sort((a, b) => {
+			const indexA = priority.indexOf(a);
+			const indexB = priority.indexOf(b);
 
-	    // If both positions are in the priority list, sort by their order
-	    if (indexA !== -1 && indexB !== -1) {
-	        return indexA - indexB;
-	    }
-	    // If only one is in the priority list, prioritize it
-	    if (indexA !== -1) return -1;
-	    if (indexB !== -1) return 1;
+			// If both positions are in the priority list, sort by their order
+			if (indexA !== -1 && indexB !== -1) {
+				return indexA - indexB;
+			}
+			// If only one is in the priority list, prioritize it
+			if (indexA !== -1) return -1;
+			if (indexB !== -1) return 1;
 
-	    // Otherwise, sort alphabetically
-	    return a.localeCompare(b);
-	});
+			// Otherwise, sort alphabetically
+			return a.localeCompare(b);
+		});
 
 	$: peopleByPosition = positions.map((position) => ({
 		position,

--- a/website-frontend/src/routes/people/[slug]/+page.svelte
+++ b/website-frontend/src/routes/people/[slug]/+page.svelte
@@ -10,9 +10,33 @@
 
 	$: ({ category, people } = data);
 
+	const priority = [
+	    "Professor", 
+	    "Associate Professor", 
+	    "Assistant Professor", 
+	    "Instructor", 
+	    "Lecturer", 
+	    "Researcher"
+	];
+
 	$: positions = Array.from(
-		new Set(people.map((person: Person) => person.position).filter(Boolean))
-	);
+	    new Set(people.map((person: Person) => person.position).filter(Boolean))
+	).map(pos => pos as string).sort((a, b) => {
+	    const indexA = priority.indexOf(a);
+	    const indexB = priority.indexOf(b);
+
+	    // If both positions are in the priority list, sort by their order
+	    if (indexA !== -1 && indexB !== -1) {
+	        return indexA - indexB;
+	    }
+	    // If only one is in the priority list, prioritize it
+	    if (indexA !== -1) return -1;
+	    if (indexB !== -1) return 1;
+
+	    // Otherwise, sort alphabetically
+	    return a.localeCompare(b);
+	});
+	
 	$: peopleByPosition = positions.map((position) => ({
 		position,
 		people: people.filter((person: Person) => person.position === position)

--- a/website-frontend/src/routes/people/[slug]/+page.svelte
+++ b/website-frontend/src/routes/people/[slug]/+page.svelte
@@ -10,10 +10,12 @@
 
 	$: ({ category, people } = data);
 
-	$: positions = Array.from(new Set(people.map((person: Person) => person.position).filter(Boolean)));
+	$: positions = Array.from(
+		new Set(people.map((person: Person) => person.position).filter(Boolean))
+	);
 	$: peopleByPosition = positions.map((position) => ({
-	    position,
-	    people: people.filter((person: Person) => person.position === position)
+		position,
+		people: people.filter((person: Person) => person.position === position)
 	}));
 </script>
 
@@ -27,24 +29,25 @@
 
 		<div class="flex justify-center px-4">
 			<div class="content-padding">
-
 				<div class="pt-5">
 					<Breadcrumb />
 				</div>
 
-				{#each peopleByPosition as { position, people } }
+				{#each peopleByPosition as { position, people }}
 					<div>
 						<p class="heading-text">{position}s</p>
 						<CardPanel>
 							{#each people as person (person.username)}
 								<a href="/people/{person.category}/{person.username}">
-									<PeopleCard {person} laboratory={person.affiliations?.[0]?.laboratories_id?.name} />
+									<PeopleCard
+										{person}
+										laboratory={person.affiliations?.[0]?.laboratories_id?.name}
+									/>
 								</a>
 							{/each}
 						</CardPanel>
 					</div>
 				{/each}
-
 			</div>
 		</div>
 	{:else}

--- a/website-frontend/src/routes/people/[slug]/+page.svelte
+++ b/website-frontend/src/routes/people/[slug]/+page.svelte
@@ -11,32 +11,34 @@
 	$: ({ category, people } = data);
 
 	const priority = [
-	    "Professor", 
-	    "Associate Professor", 
-	    "Assistant Professor", 
-	    "Instructor", 
-	    "Lecturer", 
-	    "Researcher"
+		'Professor',
+		'Associate Professor',
+		'Assistant Professor',
+		'Instructor',
+		'Lecturer',
+		'Researcher'
 	];
 
 	$: positions = Array.from(
-	    new Set(people.map((person: Person) => person.position).filter(Boolean))
-	).map(pos => pos as string).sort((a, b) => {
-	    const indexA = priority.indexOf(a);
-	    const indexB = priority.indexOf(b);
+		new Set(people.map((person: Person) => person.position).filter(Boolean))
+	)
+		.map((pos) => pos as string)
+		.sort((a, b) => {
+			const indexA = priority.indexOf(a);
+			const indexB = priority.indexOf(b);
 
-	    // If both positions are in the priority list, sort by their order
-	    if (indexA !== -1 && indexB !== -1) {
-	        return indexA - indexB;
-	    }
-	    // If only one is in the priority list, prioritize it
-	    if (indexA !== -1) return -1;
-	    if (indexB !== -1) return 1;
+			// If both positions are in the priority list, sort by their order
+			if (indexA !== -1 && indexB !== -1) {
+				return indexA - indexB;
+			}
+			// If only one is in the priority list, prioritize it
+			if (indexA !== -1) return -1;
+			if (indexB !== -1) return 1;
 
-	    // Otherwise, sort alphabetically
-	    return a.localeCompare(b);
-	});
-	
+			// Otherwise, sort alphabetically
+			return a.localeCompare(b);
+		});
+
 	$: peopleByPosition = positions.map((position) => ({
 		position,
 		people: people.filter((person: Person) => person.position === position)

--- a/website-frontend/src/routes/people/[slug]/+page.svelte
+++ b/website-frontend/src/routes/people/[slug]/+page.svelte
@@ -4,34 +4,48 @@
 	import CardPanel from '$lib/components/panel/CardPanel.svelte';
 	import PeopleCard from '$lib/components/cards/PeopleCard.svelte';
 	import Breadcrumb from '$lib/components/breadcrumbs/PageBreadcrumb.svelte';
+	import { Person } from '$lib/models/people';
 
 	export let data;
 
 	$: ({ category, people } = data);
+
+	$: positions = Array.from(new Set(people.map((person: Person) => person.position).filter(Boolean)));
+	$: peopleByPosition = positions.map((position) => ({
+	    position,
+	    people: people.filter((person: Person) => person.position === position)
+	}));
 </script>
 
 <body>
 	{#if category}
-		<div class="relative z-0">
-			<Banner
-				title={category.title}
-				background_image={category.background_image ?? ''}
-				flexible_content={category.flexible_content}
-			/>
-		</div>
+		<Banner
+			title={category.title}
+			background_image={category.background_image ?? ''}
+			flexible_content={category.flexible_content}
+		/>
 
-		<div class="mx-auto w-[94vw] md:w-[80vw]">
-			<div class="mt-5">
-				<Breadcrumb />
-			</div>
+		<div class="flex justify-center px-4">
+			<div class="content-padding">
 
-			<CardPanel>
-				{#each people as person}
-					<a href="/people/{category.title}/{person.username}">
-						<PeopleCard {person} laboratory={person.affiliations?.[0]?.laboratories_id?.name} />
-					</a>
+				<div class="pt-5">
+					<Breadcrumb />
+				</div>
+
+				{#each peopleByPosition as { position, people } }
+					<div>
+						<p class="heading-text">{position}s</p>
+						<CardPanel>
+							{#each people as person (person.username)}
+								<a href="/people/{person.category}/{person.username}">
+									<PeopleCard {person} laboratory={person.affiliations?.[0]?.laboratories_id?.name} />
+								</a>
+							{/each}
+						</CardPanel>
+					</div>
 				{/each}
-			</CardPanel>
+
+			</div>
 		</div>
 	{:else}
 		<p>People category not found</p>


### PR DESCRIPTION
This PR adds division by rank in the people pages. Let me know if the ranks need to be arranged in a specific order!

Additionally:
- Made minor edits to the `CardPanel` component:
  - Removed the bottom padding.
- Note: Further styling changes are still needed for `CardPanel`. The cards should be left-aligned rather than centered when there aren’t enough cards for a full row. This will be addressed in a separate PR.