### PR TITLE
fix: explicitly detail docker syntax

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 FROM node:lts AS builder
 
 WORKDIR /app


### PR DESCRIPTION
This PR fixes the current issue with the Docker deployment action by explicitly setting the Dockerfile syntax version.