### PR TITLE
fix: close mobile navbar on `NavItem` click

### DIFF
--- a/website-frontend/src/lib/components/list_items/NavItem.svelte
+++ b/website-frontend/src/lib/components/list_items/NavItem.svelte
@@ -72,9 +72,13 @@
 		<Accordion.Root>
 			<Accordion.Item value={to} class="border-none">
 				<div class="flex items-center justify-start">
-					<a {href} class="mr-5" on:click={() => {
-			$mobileOpen = false;
-		}}>{to}</a>
+					<a
+						{href}
+						class="mr-5"
+						on:click={() => {
+							$mobileOpen = false;
+						}}>{to}</a
+					>
 					<Accordion.Trigger class="py-0" />
 				</div>
 				<Accordion.Content>
@@ -83,8 +87,11 @@
 			</Accordion.Item>
 		</Accordion.Root>
 	{:else}
-		<a {href} on:click={() => {
-			$mobileOpen = false;
-		}}>{to}</a>
+		<a
+			{href}
+			on:click={() => {
+				$mobileOpen = false;
+			}}>{to}</a
+		>
 	{/if}
 </div>

--- a/website-frontend/src/lib/components/list_items/NavItem.svelte
+++ b/website-frontend/src/lib/components/list_items/NavItem.svelte
@@ -3,6 +3,7 @@
 	import Button from '$lib/@shadcn-svelte/ui/button/button.svelte';
 	import { ChevronDown, ChevronUp } from 'lucide-svelte';
 	import { page } from '$app/stores';
+	import { mobileOpen } from '$lib/stores';
 
 	export let href: string,
 		to: string,
@@ -71,7 +72,9 @@
 		<Accordion.Root>
 			<Accordion.Item value={to} class="border-none">
 				<div class="flex items-center justify-start">
-					<a {href} class="mr-5">{to}</a>
+					<a {href} class="mr-5" on:click={() => {
+			$mobileOpen = false;
+		}}>{to}</a>
 					<Accordion.Trigger class="py-0" />
 				</div>
 				<Accordion.Content>
@@ -80,6 +83,8 @@
 			</Accordion.Item>
 		</Accordion.Root>
 	{:else}
-		<a {href}>{to}</a>
+		<a {href} on:click={() => {
+			$mobileOpen = false;
+		}}>{to}</a>
 	{/if}
 </div>


### PR DESCRIPTION
This PR patches a bug where the mobile navbar fails to close on `NavItem` click.