### PR TITLE
fix: patch minor bugs

### DIFF
--- a/website-frontend/src/app.html
+++ b/website-frontend/src/app.html
@@ -11,7 +11,7 @@
 		/>
 		%sveltekit.head%
 	</head>
-	<body class="h-screen" data-sveltekit-preload-data="hover" data-theme="skeleton">
+	<body data-sveltekit-preload-data="hover" data-theme="skeleton">
 		<div style="display: contents">%sveltekit.body%</div>
 	</body>
 </html>

--- a/website-frontend/src/lib/components/breadcrumbs/PageBreadcrumb.svelte
+++ b/website-frontend/src/lib/components/breadcrumbs/PageBreadcrumb.svelte
@@ -52,18 +52,18 @@
 	</Breadcrumb.Root>
 </div>
 
-<div class="border-b border-muted-foreground/40 pb-1 md:pb-2 lg:hidden">
+<div class="my-4 border-b border-muted-foreground/40 pb-1 md:pb-2 lg:hidden">
 	<Breadcrumb.Root>
 		<Breadcrumb.List class="text-xs font-medium hover:text-primary">
 			<Breadcrumb.Item class="text-foreground">
 				<Breadcrumb.Link href="/">Home</Breadcrumb.Link>
 			</Breadcrumb.Item>
-			{#if to_current_path}
+			{#if to_current_path.length > 0}
 				<Breadcrumb.Separator>/</Breadcrumb.Separator>
 				<Breadcrumb.Item class="text-foreground">
 					<DropdownMenu.Root>
 						<DropdownMenu.Trigger class="flex items-center gap-1">
-							<Breadcrumb.Ellipsis />
+							<Breadcrumb.Ellipsis class="h-4 w-4" />
 							<ChevronDown class="h-4 w-4" />
 						</DropdownMenu.Trigger>
 						<DropdownMenu.Content align="start">

--- a/website-frontend/src/routes/+page.svelte
+++ b/website-frontend/src/routes/+page.svelte
@@ -40,7 +40,7 @@
 			<div class="heading-padding flex items-center justify-between text-primary-dark">
 				<h2 class="heading-text border-l-[5px] border-secondary-red pl-2">Recent Events</h2>
 				<Button
-					href="#more-news"
+					href="/events"
 					variant="outline"
 					class="flex h-auto gap-x-1 rounded-full text-[0.8rem]"
 				>


### PR DESCRIPTION
This PR addresses minor issues in the maintenance list:
- "From Safari and Chrome mobile, the footer is not displaying properly.": 
  - The **_entire frontend_** is not displaying properly in both Safari and Chrome mobile, except for the landing heroes and the banners.
  - Had a feeling that it's because of the `h-screen` class in the `<body>` tag in `app.html`, so I removed it. Adding `overflow-scroll` instead of removing the `h-screen` class *might* probably work as well.
- "Fix routing issue when selecting view all from the home page": fixed it na hooray 