### PR TITLE
feat: add course syllabus link display in academics courses

### DIFF
--- a/website-frontend/src/lib/components/buttons/ShowMoreCourseDetails.svelte
+++ b/website-frontend/src/lib/components/buttons/ShowMoreCourseDetails.svelte
@@ -2,6 +2,7 @@
 	import { Button } from '$lib/@shadcn-svelte/ui/button/index.js';
 	import { ChevronDown, ChevronUp } from 'lucide-svelte';
 	export let course_units;
+	export let course_syllabus;
 	let isDetailsHidden: boolean = true;
 </script>
 
@@ -20,7 +21,12 @@
 >
 
 {#if !isDetailsHidden}
-	<small class="mt-2 flex text-xs">
+	<small class="mt-2 flex flex-col text-xs">
 		<p>Units: {course_units}</p>
+		{#if course_syllabus}
+			<p class="italic text-blue-500 underline">
+				<a href={course_syllabus} target="_blank">Syllabus</a>
+			</p>
+		{/if}
 	</small>
 {/if}

--- a/website-frontend/src/lib/components/table/CoursesTable.svelte
+++ b/website-frontend/src/lib/components/table/CoursesTable.svelte
@@ -29,7 +29,7 @@
 				</Table.Row>
 			</Table.Header>
 			<Table.Body>
-				{#each academics_courses as { course_code, course_title, course_description, course_units }}
+				{#each academics_courses as { course_code, course_title, course_description, course_units, course_syllabus }}
 					<Table.Row>
 						<Table.Cell
 							class="w-1/12 min-w-20 bg-white text-xs text-gray-600 md:min-w-28 md:text-sm"
@@ -43,7 +43,7 @@
 							{#if course_description}
 								{course_description}
 							{/if}
-							<ShowMoreCourseDetails {course_units} />
+							<ShowMoreCourseDetails {course_units} {course_syllabus} />
 						</Table.Cell>
 					</Table.Row>
 				{/each}

--- a/website-frontend/src/lib/models/academics_courses.ts
+++ b/website-frontend/src/lib/models/academics_courses.ts
@@ -17,6 +17,7 @@ export const AcademicsCourse = object({
 	course_title: string(),
 	course_units: pipe(number(), integer()),
 	course_description: nullable(string()),
+	course_syllabus: nullable(string()),
 	related_academics_programs: union([array(number()), lazy(() => AcademicsProgramsCourses)])
 });
 


### PR DESCRIPTION
This PR adds a display to the course syllabus link in academics courses if the course syllabus link exists in the CMS.