### PR TITLE
fix: add redirect routes to missing breadcrumb links

### DIFF
--- a/website-frontend/src/routes/news/+page.server.ts
+++ b/website-frontend/src/routes/news/+page.server.ts
@@ -1,0 +1,5 @@
+import { redirect } from '@sveltejs/kit';
+
+export function load() {
+	throw redirect(308, `/#more-news`);
+}

--- a/website-frontend/src/routes/research/labs/+page.server.ts
+++ b/website-frontend/src/routes/research/labs/+page.server.ts
@@ -1,0 +1,5 @@
+import { redirect } from '@sveltejs/kit';
+
+export function load() {
+	throw redirect(308, `/research`);
+}


### PR DESCRIPTION
This PR adds redirect routes to missing breadcrumb links.