### PR TITLE
fix: apply dynamic image scaling and UI bug fixes

### DIFF
--- a/website-frontend/src/lib/components/banners/Banner.svelte
+++ b/website-frontend/src/lib/components/banners/Banner.svelte
@@ -4,15 +4,16 @@
 	export let title: string;
 	export let background_image: string = '';
 	export let flexible_content: string = '';
+	let banner_height: number;
 
 	let background =
 		'background-image: linear-gradient(to top, hsl(var(--primary)) -20%, hsl(var(--secondary)) 55%)';
-	$: if (background_image) {
-		background = `background-image: linear-gradient(to top, hsl(var(--primary)) -20%, transparent 55%), url('${PUBLIC_APIURL}/assets/${background_image}?height=720')`;
+	$: if (background_image && banner_height) {
+		background = `background-image: linear-gradient(to top, hsl(var(--primary)) -20%, transparent 55%), url('${PUBLIC_APIURL}/assets/${background_image}?height=${banner_height}')`;
 	}
 </script>
 
-<div class="relative z-0">
+<div class="relative z-0" bind:clientHeight={banner_height}>
 	<div class="h-[45vh] bg-cover bg-center md:h-[60vh]" style={background}></div>
 
 	<div

--- a/website-frontend/src/lib/components/banners/EventBanner.svelte
+++ b/website-frontend/src/lib/components/banners/EventBanner.svelte
@@ -8,6 +8,7 @@
 	export let display_location: string;
 	export let start_date: 'datetime';
 	export let end_date: 'datetime' | null;
+	let banner_height: number;
 
 	// function to extract date
 
@@ -46,13 +47,16 @@
 	if (end_date) {
 		({ hours: endHours, minutes: endMinutes } = getTimeParts(end_date));
 	}
+
+	let background =
+		'background-image: linear-gradient(to top, hsl(var(--primary)) -20%, hsl(var(--secondary)) 55%)';
+	$: if (background_image && banner_height) {
+		background = `background-image: linear-gradient(to top, #343541, transparent), url('${PUBLIC_APIURL}/assets/${background_image}?height=${banner_height}')`;
+	}
 </script>
 
-<div class="relative z-0">
-	<div
-		class="h-[40vh] bg-cover bg-center md:h-[70vh]"
-		style="background-image: linear-gradient(to top, #343541, transparent), url('{PUBLIC_APIURL}/assets/{background_image}?height=720')"
-	></div>
+<div class="relative z-0" bind:clientHeight={banner_height}>
+	<div class="h-[40vh] bg-cover bg-center md:h-[70vh]" style={background}></div>
 
 	<div
 		class="-mt-[0.4px] w-full bg-[#343541] pb-10 pt-10 md:absolute md:bottom-10 md:bg-transparent md:pb-0"

--- a/website-frontend/src/lib/components/banners/PeopleBanner.svelte
+++ b/website-frontend/src/lib/components/banners/PeopleBanner.svelte
@@ -12,13 +12,19 @@
 	export let email: string = '';
 	export let laboratory: string = '';
 	export let website: string = '';
+
+	let banner_height: number;
+	let profile_width: number;
+	let profile_height: number;
 </script>
 
-<div class="bg-background-dark">
-	<div
-		class="h-[45vh] bg-cover bg-center lg:h-[83vh]"
-		style="background-image: linear-gradient(to top, #343541, transparent), url('{PUBLIC_APIURL}/assets/{background_image}?height=720')"
-	></div>
+<div class="bg-background-dark" bind:clientHeight={banner_height}>
+	{#if background_image && banner_height}
+		<div
+			class="h-[45vh] bg-cover bg-center lg:h-[83vh]"
+			style="background-image: linear-gradient(to top, #343541, transparent), url('{PUBLIC_APIURL}/assets/{background_image}?height={banner_height}')"
+		></div>
+	{/if}
 
 	<div class="-mt-14 w-full px-4 lg:absolute lg:-bottom-16 lg:px-32">
 		<Breadcrumb page_name="{first_name} {last_name}" />
@@ -27,12 +33,14 @@
 			class="flex w-full flex-col items-center pt-10 text-secondary-foreground lg:bottom-10 lg:flex-row lg:py-10"
 		>
 			<div
+				bind:clientWidth={profile_width}
+				bind:clientHeight={profile_height}
 				class="mx-auto flex h-32 w-32 flex-shrink-0 items-center justify-center rounded-full bg-gradient-to-t from-[#667080] to-[#D1D8DD] md:h-48 md:w-48"
 			>
-				{#if profile_image}
+				{#if profile_image && profile_width && profile_height}
 					<img
 						class="h-full w-full rounded-full object-cover"
-						src="{PUBLIC_APIURL}/assets/{profile_image}?fit=cover&width=360&height=360"
+						src="{PUBLIC_APIURL}/assets/{profile_image}?fit=cover&width={profile_width}&height={profile_height}"
 						alt="{first_name} {last_name}'s profile picture"
 					/>
 				{:else}

--- a/website-frontend/src/lib/components/banners/PeopleBanner.svelte
+++ b/website-frontend/src/lib/components/banners/PeopleBanner.svelte
@@ -14,8 +14,8 @@
 	export let website: string = '';
 
 	let banner_height: number;
-	let profile_width: number;
 	let profile_height: number;
+	$: profile_width = profile_height;
 </script>
 
 <div class="bg-background-dark" bind:clientHeight={banner_height}>
@@ -33,7 +33,6 @@
 			class="flex w-full flex-col items-center pt-10 text-secondary-foreground lg:bottom-10 lg:flex-row lg:py-10"
 		>
 			<div
-				bind:clientWidth={profile_width}
 				bind:clientHeight={profile_height}
 				class="mx-auto flex h-32 w-32 flex-shrink-0 items-center justify-center rounded-full bg-gradient-to-t from-[#667080] to-[#D1D8DD] md:h-48 md:w-48"
 			>

--- a/website-frontend/src/lib/components/cards/AlumCard.svelte
+++ b/website-frontend/src/lib/components/cards/AlumCard.svelte
@@ -3,16 +3,25 @@
 	import * as Dialog from '$lib/@shadcn-svelte/ui/dialog';
 	import { Alum } from '$lib/models/alumni';
 	export let alum: Alum;
+	let trigger_banner_height: number;
+	let content_banner_height: number;
+	let trigger_profile_width: number;
+	let trigger_profile_height: number;
+	let content_profile_width: number;
+	let content_profile_height: number;
 </script>
 
 <Dialog.Root>
 	<Dialog.Trigger class="h-full w-full pt-20">
 		<div class="card group relative flex h-full w-full flex-col overflow-hidden">
-			<div class="inset-0 h-36 overflow-hidden rounded-t-lg bg-gray-300 md:h-52">
-				{#if alum.background_image}
+			<div
+				class="inset-0 h-36 overflow-hidden rounded-t-lg bg-gray-300 md:h-52"
+				bind:clientHeight={trigger_banner_height}
+			>
+				{#if alum.background_image && trigger_banner_height}
 					<img
 						class="h-full w-full rounded-t-lg object-cover transition-transform duration-300 ease-out group-hover:scale-105"
-						src="{PUBLIC_APIURL}/assets/{alum.background_image}?height=360"
+						src="{PUBLIC_APIURL}/assets/{alum.background_image}?height={trigger_banner_height}"
 						alt="Background"
 					/>
 				{/if}
@@ -21,15 +30,17 @@
 			<div class="z-10 -mt-16 items-center px-3 md:-mt-20">
 				<div
 					class="relative mx-auto flex h-28 w-28 items-center justify-center rounded-full md:h-32 md:w-32"
+					bind:clientWidth={trigger_profile_width}
+					bind:clientHeight={trigger_profile_height}
 				>
 					<div
 						class="absolute -inset-[2px] -z-10 rounded-full border-2 border-primary/20 backdrop-blur-lg md:-inset-1 md:border-4"
 					></div>
 
-					{#if alum.profile_image}
+					{#if alum.profile_image && trigger_profile_width && trigger_profile_height}
 						<img
 							class="h-full w-full rounded-full object-cover"
-							src="{PUBLIC_APIURL}/assets/{alum.profile_image}?fit=cover&width=180&height=180"
+							src="{PUBLIC_APIURL}/assets/{alum.profile_image}?fit=cover&width={trigger_profile_width}&height={trigger_profile_height}"
 							alt="Profile"
 						/>
 					{:else}
@@ -68,11 +79,14 @@
 	</Dialog.Trigger>
 	<Dialog.Content class="mx-auto w-full rounded-lg">
 		<div class="group relative flex h-full w-full flex-col overflow-hidden pt-5">
-			<div class="inset-0 h-36 overflow-hidden rounded-t-lg bg-gray-300 md:h-52">
-				{#if alum.background_image}
+			<div
+				class="inset-0 h-36 overflow-hidden rounded-t-lg bg-gray-300 md:h-52"
+				bind:clientHeight={content_banner_height}
+			>
+				{#if alum.background_image && content_banner_height}
 					<img
 						class="h-full w-full rounded-t-lg object-cover"
-						src="{PUBLIC_APIURL}/assets/{alum.background_image}?height=360"
+						src="{PUBLIC_APIURL}/assets/{alum.background_image}?height={content_banner_height}"
 						alt="Background"
 					/>
 				{/if}
@@ -81,15 +95,17 @@
 			<div class="z-10 -mt-16 items-center px-3 md:-mt-20">
 				<div
 					class="relative mx-auto flex h-28 w-28 items-center justify-center rounded-full md:h-32 md:w-32"
+					bind:clientWidth={content_profile_width}
+					bind:clientHeight={content_profile_height}
 				>
 					<div
 						class="absolute -inset-[2px] -z-10 rounded-full border-2 border-primary/20 backdrop-blur-lg md:-inset-1 md:border-4"
 					></div>
 
-					{#if alum.profile_image}
+					{#if alum.profile_image && content_profile_width && content_profile_height}
 						<img
 							class="h-full w-full rounded-full object-cover"
-							src="{PUBLIC_APIURL}/assets/{alum.profile_image}?fit=cover&width=180&height=180"
+							src="{PUBLIC_APIURL}/assets/{alum.profile_image}?fit=cover&width={content_profile_width}&height={content_profile_height}"
 							alt="Profile"
 						/>
 					{:else}

--- a/website-frontend/src/lib/components/cards/AlumCard.svelte
+++ b/website-frontend/src/lib/components/cards/AlumCard.svelte
@@ -5,10 +5,10 @@
 	export let alum: Alum;
 	let trigger_banner_height: number;
 	let content_banner_height: number;
-	let trigger_profile_width: number;
 	let trigger_profile_height: number;
-	let content_profile_width: number;
+	$: trigger_profile_width = trigger_profile_height;
 	let content_profile_height: number;
+	$: content_profile_width = content_profile_height;
 </script>
 
 <Dialog.Root>
@@ -30,7 +30,6 @@
 			<div class="z-10 -mt-16 items-center px-3 md:-mt-20">
 				<div
 					class="relative mx-auto flex h-28 w-28 items-center justify-center rounded-full md:h-32 md:w-32"
-					bind:clientWidth={trigger_profile_width}
 					bind:clientHeight={trigger_profile_height}
 				>
 					<div
@@ -95,7 +94,6 @@
 			<div class="z-10 -mt-16 items-center px-3 md:-mt-20">
 				<div
 					class="relative mx-auto flex h-28 w-28 items-center justify-center rounded-full md:h-32 md:w-32"
-					bind:clientWidth={content_profile_width}
 					bind:clientHeight={content_profile_height}
 				>
 					<div

--- a/website-frontend/src/lib/components/cards/FeaturedEventCard.svelte
+++ b/website-frontend/src/lib/components/cards/FeaturedEventCard.svelte
@@ -4,6 +4,7 @@
 	import { Calendar, MapPin, Clock, Image } from 'lucide-svelte';
 	import { reloading } from '$lib/stores';
 	export let item: Event;
+	let hero_height: number;
 
 	function formatTimeRange(startTime: string, endTime: string) {
 		const start = new Date(startTime);
@@ -52,12 +53,13 @@
 			{item.hero_image
 				? ''
 				: 'flex items-center justify-center bg-gradient-to-b from-[#D1D8DD] to-[#66708076]'}"
+			bind:clientHeight={hero_height}
 		>
-			{#if item.hero_image}
+			{#if item.hero_image && hero_height}
 				<div class="h-full w-full">
 					<img
 						class="h-full w-full rounded-t-lg object-cover transition-transform duration-300 ease-out group-hover:scale-105"
-						src="{PUBLIC_APIURL}/assets/{item.hero_image}?height=360"
+						src="{PUBLIC_APIURL}/assets/{item.hero_image}?height={hero_height}"
 						alt="Background"
 					/>
 				</div>

--- a/website-frontend/src/lib/components/cards/HorizontalCard.svelte
+++ b/website-frontend/src/lib/components/cards/HorizontalCard.svelte
@@ -11,8 +11,8 @@
 		height = 'h-40';
 	}
 
-	let logo_width: number;
 	let logo_height: number;
+	$: logo_width = logo_height;
 </script>
 
 <div class="card group relative flex h-auto w-full flex-col overflow-hidden">
@@ -22,7 +22,6 @@
 
 	<div
 		class="absolute flex h-full items-center px-5 text-white {logo_image ? 'md:px-6' : 'md:px-11'}"
-		bind:clientWidth={logo_width}
 		bind:clientHeight={logo_height}
 	>
 		{#if logo_image && logo_width && logo_height}

--- a/website-frontend/src/lib/components/cards/HorizontalCard.svelte
+++ b/website-frontend/src/lib/components/cards/HorizontalCard.svelte
@@ -10,6 +10,9 @@
 	$: if (description) {
 		height = 'h-40';
 	}
+
+	let logo_width: number;
+	let logo_height: number;
 </script>
 
 <div class="card group relative flex h-auto w-full flex-col overflow-hidden">
@@ -19,11 +22,13 @@
 
 	<div
 		class="absolute flex h-full items-center px-5 text-white {logo_image ? 'md:px-6' : 'md:px-11'}"
+		bind:clientWidth={logo_width}
+		bind:clientHeight={logo_height}
 	>
-		{#if logo_image}
+		{#if logo_image && logo_width && logo_height}
 			<img
 				class="mr-6 hidden h-28 w-28 rounded-full object-cover md:block"
-				src="{PUBLIC_APIURL}/assets/{logo_image}?fit=cover&width=360&height=360"
+				src="{PUBLIC_APIURL}/assets/{logo_image}?fit=cover&width={logo_width}&height={logo_height}"
 				alt="logo"
 			/>
 		{/if}

--- a/website-frontend/src/lib/components/cards/NewsCard.svelte
+++ b/website-frontend/src/lib/components/cards/NewsCard.svelte
@@ -13,6 +13,8 @@
 				if (typeof news_tags_id !== 'string') return news_tags_id?.name;
 				else return error(500);
 			}) ?? [];
+
+	let banner_height: number;
 </script>
 
 <a
@@ -30,12 +32,13 @@
 		{item.background_image
 				? ''
 				: 'flex items-center justify-center bg-gradient-to-b from-[#D1D8DD] to-[#66708076]'}"
+			bind:clientHeight={banner_height}
 		>
-			{#if item.background_image}
+			{#if item.background_image && banner_height}
 				<div class="h-full w-full">
 					<img
 						class="h-full w-full rounded-t-lg object-cover transition-transform duration-300 ease-out group-hover:scale-105"
-						src="{PUBLIC_APIURL}/assets/{item.background_image}?height=360"
+						src="{PUBLIC_APIURL}/assets/{item.background_image}?height={banner_height}"
 						alt="Background"
 					/>
 				</div>

--- a/website-frontend/src/lib/components/cards/PartnerCard.svelte
+++ b/website-frontend/src/lib/components/cards/PartnerCard.svelte
@@ -9,6 +9,8 @@
 	import type { Partnership } from '$lib/models/partnerships';
 
 	export let partner: Partnership;
+	let trigger_banner_height: number;
+	let content_banner_height: number;
 	$: ({ display_image, name, description } = partner);
 </script>
 
@@ -17,11 +19,11 @@
 		<Card.Root class="card h-full w-full border-0">
 			<Card.Content class="card h-full w-full p-4">
 				<div class="flex flex-col gap-y-5">
-					<div class="flex">
-						{#if display_image}
+					<div class="flex" bind:clientHeight={trigger_banner_height}>
+						{#if display_image && trigger_banner_height}
 							<img
 								class="h-32 object-contain"
-								src="{PUBLIC_APIURL}/assets/{display_image}?height=360"
+								src="{PUBLIC_APIURL}/assets/{display_image}?height={trigger_banner_height}"
 								alt={name}
 							/>
 						{:else}
@@ -41,11 +43,11 @@
 	</Dialog.Trigger>
 	<Dialog.Content class="mx-auto w-full max-w-[90vw] rounded-lg md:max-w-lg">
 		<Dialog.Header class="flex flex-col gap-y-2">
-			<div class="relative flex">
-				{#if display_image}
+			<div class="relative flex" bind:clientHeight={content_banner_height}>
+				{#if display_image && content_banner_height}
 					<img
 						class="h-32 object-contain"
-						src="{PUBLIC_APIURL}/assets/{display_image}?height=360"
+						src="{PUBLIC_APIURL}/assets/{display_image}?height={content_banner_height}"
 						alt={name}
 					/>
 				{:else}

--- a/website-frontend/src/lib/components/cards/PeopleCard.svelte
+++ b/website-frontend/src/lib/components/cards/PeopleCard.svelte
@@ -5,14 +5,21 @@
 
 	export let item: Person;
 	export let laboratory: string = '';
+
+	let banner_height: number;
+	let profile_width: number;
+	let profile_height: number;
 </script>
 
 <div class="card group relative flex h-full w-full flex-col overflow-hidden">
-	<div class="inset-0 h-36 overflow-hidden rounded-t-lg bg-gray-300 md:h-52">
-		{#if item.background_image}
+	<div
+		class="inset-0 h-36 overflow-hidden rounded-t-lg bg-gray-300 md:h-52"
+		bind:clientHeight={banner_height}
+	>
+		{#if item.background_image && banner_height}
 			<img
 				class="h-full w-full rounded-t-lg object-cover transition-transform duration-300 ease-out group-hover:scale-105"
-				src="{PUBLIC_APIURL}/assets/{item.background_image}?height=360"
+				src="{PUBLIC_APIURL}/assets/{item.background_image}?height={banner_height}"
 				alt="Background"
 			/>
 		{/if}
@@ -21,15 +28,17 @@
 	<div class="z-10 -mt-16 items-center px-3 md:-mt-20">
 		<div
 			class="relative mx-auto flex h-28 w-28 items-center justify-center rounded-full md:h-32 md:w-32"
+			bind:clientWidth={profile_width}
+			bind:clientHeight={profile_height}
 		>
 			<div
 				class="absolute -inset-[2px] -z-10 rounded-full border-2 border-primary/20 backdrop-blur-lg md:-inset-1 md:border-4"
 			></div>
 
-			{#if item.profile_image}
+			{#if item.profile_image && profile_width && profile_height}
 				<img
 					class="h-full w-full rounded-full object-cover"
-					src="{PUBLIC_APIURL}/assets/{item.profile_image}?fit=cover&width=180&height=180"
+					src="{PUBLIC_APIURL}/assets/{item.profile_image}?fit=cover&width={profile_width}&height={profile_height}"
 					alt="Profile"
 				/>
 			{:else}

--- a/website-frontend/src/lib/components/cards/PeopleCard.svelte
+++ b/website-frontend/src/lib/components/cards/PeopleCard.svelte
@@ -7,8 +7,8 @@
 	export let laboratory: string = '';
 
 	let banner_height: number;
-	let profile_width: number;
 	let profile_height: number;
+	$: profile_width = profile_height;
 </script>
 
 <div class="card group relative flex h-full w-full flex-col overflow-hidden">
@@ -28,7 +28,6 @@
 	<div class="z-10 -mt-16 items-center px-3 md:-mt-20">
 		<div
 			class="relative mx-auto flex h-28 w-28 items-center justify-center rounded-full md:h-32 md:w-32"
-			bind:clientWidth={profile_width}
 			bind:clientHeight={profile_height}
 		>
 			<div

--- a/website-frontend/src/lib/components/cards/PublicationCard.svelte
+++ b/website-frontend/src/lib/components/cards/PublicationCard.svelte
@@ -9,6 +9,8 @@
 
 	export let item: Publication;
 
+	let banner_height: number;
+
 	$: publications_tags = item.publication_tags
 		? item.publication_tags
 				.filter((tag) => typeof tag === 'object')
@@ -25,10 +27,11 @@
 			<Card.Header class="relative flex h-80 flex-col items-center">
 				<div
 					class="-mt-24 w-full max-w-[calc(var(--card-height)*0.5)] flex-grow overflow-hidden rounded-lg bg-gray-100"
+					bind:clientHeight={banner_height}
 				>
-					{#if item.hero_image}
+					{#if item.hero_image && banner_height}
 						<img
-							src="{PUBLIC_APIURL}/assets/{item.hero_image}?height=360"
+							src="{PUBLIC_APIURL}/assets/{item.hero_image}?height={banner_height}"
 							alt={item.title}
 							class="h-full w-full rounded-lg object-cover"
 						/>

--- a/website-frontend/src/lib/components/carousels/LabHero.svelte
+++ b/website-frontend/src/lib/components/carousels/LabHero.svelte
@@ -33,10 +33,13 @@
 	$: if (background_images.length === 0) {
 		background_images = [`default1.jpg`, `default2.jpg`, `default3.jpg`, `default4.jpg`];
 	}
+
+	let carousel_height: number;
+	let logo_height: number;
 </script>
 
 <div>
-	<div class="relative">
+	<div class="relative" bind:clientHeight={carousel_height}>
 		<Carousel.Root
 			bind:api
 			plugins={[autoplayPlugin, fadePlugin]}
@@ -45,10 +48,12 @@
 			<Carousel.Content>
 				{#each background_images as background_image}
 					<Carousel.Item class="h-full">
-						<div
-							class="h-[82vh] bg-cover bg-center md:h-[80vh]"
-							style="background-image: linear-gradient(to top, hsl(var(--background-dark)), transparent), url('{PUBLIC_APIURL}/assets/{background_image}?height=720')"
-						></div>
+						{#if carousel_height}
+							<div
+								class="h-[82vh] bg-cover bg-center md:h-[80vh]"
+								style="background-image: linear-gradient(to top, hsl(var(--background-dark)), transparent), url('{PUBLIC_APIURL}/assets/{background_image}?height={carousel_height}')"
+							></div>
+						{/if}
 					</Carousel.Item>
 				{/each}
 			</Carousel.Content>
@@ -63,11 +68,12 @@
 		<div class="flex flex-col items-center lg:flex-row">
 			<div
 				class="mx-auto flex h-28 w-28 flex-shrink-0 items-center justify-center rounded-full border-4 border-gray-200 bg-gray-100 md:h-32 md:w-32 lg:mr-20 lg:h-40 lg:w-40"
+				bind:clientHeight={logo_height}
 			>
-				{#if logo_image}
+				{#if logo_image && logo_height}
 					<img
 						class="h-full w-full rounded-full object-cover"
-						src="{PUBLIC_APIURL}/assets/{logo_image}?fit=cover&width=180&height=180"
+						src="{PUBLIC_APIURL}/assets/{logo_image}?fit=cover&width=180&height={logo_height}"
 						alt="Logo"
 					/>
 				{:else}

--- a/website-frontend/src/lib/components/carousels/LabHero.svelte
+++ b/website-frontend/src/lib/components/carousels/LabHero.svelte
@@ -36,6 +36,7 @@
 
 	let carousel_height: number;
 	let logo_height: number;
+	$: logo_width = logo_height;
 </script>
 
 <div>
@@ -73,7 +74,7 @@
 				{#if logo_image && logo_height}
 					<img
 						class="h-full w-full rounded-full object-cover"
-						src="{PUBLIC_APIURL}/assets/{logo_image}?fit=cover&width=180&height={logo_height}"
+						src="{PUBLIC_APIURL}/assets/{logo_image}?fit=cover&width={logo_width}&height={logo_height}"
 						alt="Logo"
 					/>
 				{:else}

--- a/website-frontend/src/lib/components/carousels/LandingHero.svelte
+++ b/website-frontend/src/lib/components/carousels/LandingHero.svelte
@@ -8,6 +8,7 @@
 	import { fly } from 'svelte/transition';
 	import { cubicOut } from 'svelte/easing';
 	import { onMount } from 'svelte';
+	import { Image } from 'lucide-svelte';
 
 	const delay = 6000;
 	const plugin = Autoplay({ delay, stopOnInteraction: true });
@@ -20,6 +21,7 @@
 	let startTime = Date.now();
 	let elapsed = 0;
 	let progress = 0;
+	let carousel_height: number;
 
 	$: if (api) {
 		count = api.scrollSnapList().length;
@@ -63,17 +65,19 @@
 	});
 </script>
 
-<div>
+<div bind:clientHeight={carousel_height}>
 	<Carousel.Root bind:api plugins={[plugin, Fade()]}>
 		<Carousel.Content>
 			{#each news as news_item, index}
 				<Carousel.Item class="relative flex h-[70vh] flex-col items-center justify-end md:h-[90vh]">
-					{#if news_item.background_image}
+					{#if news_item.background_image && carousel_height}
 						<img
-							src="{PUBLIC_APIURL}/assets/{news_item.background_image}?height=1080"
+							src="{PUBLIC_APIURL}/assets/{news_item.background_image}?height={carousel_height}"
 							alt="Carousel Item"
-							class="absolute h-full w-screen object-cover"
+							class="absolute h-full w-full object-cover"
 						/>
+					{:else}
+						<Image class="h-full w-full text-secondary" />
 					{/if}
 					<div
 						class="absolute flex h-full w-screen flex-col justify-end bg-gradient-to-t from-[#0000009e] to-transparent"

--- a/website-frontend/src/lib/components/list_items/LaboratoryItem.svelte
+++ b/website-frontend/src/lib/components/list_items/LaboratoryItem.svelte
@@ -4,6 +4,8 @@
 	import { reloading } from '$lib/stores';
 
 	export let laboratory;
+	let logo_height: number;
+
 	$: ({ name, logo, description, slug } = laboratory);
 </script>
 
@@ -18,11 +20,11 @@
 		class="my-4 flex flex-col justify-center gap-6 rounded-lg p-10 text-center text-background md:flex-row md:justify-start md:text-start"
 		style="background-image: linear-gradient(to right, hsl(var(--primary)), hsl(var(--primary)/0.25)); grid-template-columns: 1fr auto;"
 	>
-		<div class="flex justify-center md:justify-start">
-			{#if logo}
+		<div class="flex justify-center md:justify-start" bind:clientHeight={logo_height}>
+			{#if logo && logo_height}
 				<div class="flex h-40 w-40 items-center justify-center">
 					<img
-						src="{PUBLIC_APIURL}/assets/{logo}?height=180"
+						src="{PUBLIC_APIURL}/assets/{logo}?height={logo_height}"
 						alt={name}
 						class="max-h-40 max-w-40"
 					/>

--- a/website-frontend/src/lib/components/list_items/OrganizationItem.svelte
+++ b/website-frontend/src/lib/components/list_items/OrganizationItem.svelte
@@ -4,6 +4,8 @@
 	import { reloading } from '$lib/stores';
 
 	export let organization;
+	let logo_height: number;
+
 	$: ({ name, logo, description, website, slug } = organization);
 </script>
 
@@ -18,11 +20,16 @@
 		class="my-4 flex flex-col justify-center gap-6 rounded-lg p-10 text-center text-background md:flex-row md:justify-start md:text-start"
 		style="background-image: linear-gradient(to right, hsl(var(--primary)), hsl(var(--primary)/0.25)); grid-template-columns: 1fr auto;"
 	>
-		<a href={website} class="flex justify-center md:justify-start" target="_blank">
-			{#if logo}
+		<a
+			href={website}
+			class="flex justify-center md:justify-start"
+			target="_blank"
+			bind:clientHeight={logo_height}
+		>
+			{#if logo && logo_height}
 				<div class="flex h-40 w-40 items-center justify-center">
 					<img
-						src="{PUBLIC_APIURL}/assets/{logo}?height=180"
+						src="{PUBLIC_APIURL}/assets/{logo}?height={logo_height}"
 						alt={name}
 						class="max-h-40 max-w-40"
 					/>

--- a/website-frontend/src/lib/components/nav/Header.svelte
+++ b/website-frontend/src/lib/components/nav/Header.svelte
@@ -25,11 +25,6 @@
 	export let laboratories;
 	export let students_pages;
 
-	let desktop_logo_height: number;
-	$: desktop_logo_width = desktop_logo_height;
-	let mobile_logo_height: number;
-	$: mobile_logo_width = mobile_logo_height;
-
 	let atTop = writable(true); // Track if at the top
 	let lastScrollY = 0;
 	let isVisible = writable(true); // Track navbar visibility
@@ -63,27 +58,20 @@
 >
 	<div class="flex justify-between px-2 lg:px-9">
 		<!-- Favicons -->
-		<div
-			class="my-auto items-center justify-center {$mobileOpen ? 'hidden' : 'flex'}"
-			bind:clientHeight={desktop_logo_height}
-		>
+		<div class="my-auto items-center justify-center {$mobileOpen ? 'hidden' : 'flex'}">
 			<a href={secondary_logo_link ? secondary_logo_link : undefined} target="_blank">
-				{#if desktop_logo_width && desktop_logo_height}
-					<img
-						src="{PUBLIC_APIURL}/assets/{secondary_logo}?fit=cover&width={desktop_logo_width}&height={desktop_logo_height}"
-						alt="UP"
-						class="mr-1 hidden h-12 w-12 max-w-xs rounded-full bg-secondary lg:block"
-					/>
-				{/if}
+				<img
+					src="{PUBLIC_APIURL}/assets/{secondary_logo}?fit=cover&width=90&height=90"
+					alt="UP"
+					class="mr-1 hidden h-12 w-12 max-w-xs rounded-full bg-secondary lg:block"
+				/>
 			</a>
 			<a href="/">
-				{#if desktop_logo_width && desktop_logo_height}
-					<img
-						src="{PUBLIC_APIURL}/assets/{primary_logo}?fit=cover&width={desktop_logo_width}&height={desktop_logo_height}"
-						alt="DCS"
-						class="mr-2 h-10 w-10 max-w-xs rounded-full bg-secondary lg:mr-3 lg:h-12 lg:w-12"
-					/>
-				{/if}
+				<img
+					src="{PUBLIC_APIURL}/assets/{primary_logo}?fit=cover&width=90&height=90"
+					alt="DCS"
+					class="mr-2 h-10 w-10 max-w-xs rounded-full bg-secondary lg:mr-3 lg:h-12 lg:w-12"
+				/>
 			</a>
 			<a href="/" class="font-semibold text-primary">
 				<h1 class="mt-[1px] text-[11px] lg:text-sm">University of the Philippines Diliman</h1>
@@ -190,27 +178,20 @@
 >
 	<nav class="w-full">
 		<!-- Favicons -->
-		<div
-			class="mt-5 flex items-center justify-center lg:hidden"
-			bind:clientHeight={mobile_logo_height}
-		>
+		<div class="mt-5 flex items-center justify-center lg:hidden">
 			<a href="/">
-				{#if mobile_logo_width && mobile_logo_height}
-					<img
-						src="{PUBLIC_APIURL}/assets/{primary_logo}?fit=cover&width={mobile_logo_width}&height={mobile_logo_height}"
-						alt="UP"
-						class="mr-1 hidden h-12 w-12 max-w-xs rounded-full bg-secondary lg:block"
-					/>
-				{/if}
+				<img
+					src="{PUBLIC_APIURL}/assets/{primary_logo}?fit=cover&width=90&height=90"
+					alt="UP"
+					class="mr-1 hidden h-12 w-12 max-w-xs rounded-full bg-secondary lg:block"
+				/>
 			</a>
 			<a href={secondary_logo_link ? secondary_logo_link : undefined} target="_blank">
-				{#if mobile_logo_width && mobile_logo_height}
-					<img
-						src="{PUBLIC_APIURL}/assets/{secondary_logo}?fit=cover&width={mobile_logo_width}&height={mobile_logo_height}"
-						alt="DCS"
-						class="mr-2 h-10 w-10 max-w-xs rounded-full bg-secondary lg:mr-3 lg:h-12 lg:w-12"
-					/>
-				{/if}
+				<img
+					src="{PUBLIC_APIURL}/assets/{secondary_logo}?fit=cover&width=90&height=90"
+					alt="DCS"
+					class="mr-2 h-10 w-10 max-w-xs rounded-full bg-secondary lg:mr-3 lg:h-12 lg:w-12"
+				/>
 			</a>
 			<div class="font-medium">
 				<h1 class="text-xs lg:text-sm">University of the Philippines Diliman</h1>

--- a/website-frontend/src/lib/components/nav/Header.svelte
+++ b/website-frontend/src/lib/components/nav/Header.svelte
@@ -25,6 +25,11 @@
 	export let laboratories;
 	export let students_pages;
 
+	let desktop_logo_height: number;
+	$: desktop_logo_width = desktop_logo_height;
+	let mobile_logo_height: number;
+	$: mobile_logo_width = mobile_logo_height;
+
 	let atTop = writable(true); // Track if at the top
 	let lastScrollY = 0;
 	let isVisible = writable(true); // Track navbar visibility
@@ -58,20 +63,27 @@
 >
 	<div class="flex justify-between px-2 lg:px-9">
 		<!-- Favicons -->
-		<div class="my-auto items-center justify-center {$mobileOpen ? 'hidden' : 'flex'}">
+		<div
+			class="my-auto items-center justify-center {$mobileOpen ? 'hidden' : 'flex'}"
+			bind:clientHeight={desktop_logo_height}
+		>
 			<a href={secondary_logo_link ? secondary_logo_link : undefined} target="_blank">
-				<img
-					src="{PUBLIC_APIURL}/assets/{secondary_logo}?fit=cover&width=90&height=90"
-					alt="UP"
-					class="mr-1 hidden h-12 w-12 max-w-xs rounded-full bg-secondary lg:block"
-				/>
+				{#if desktop_logo_width && desktop_logo_height}
+					<img
+						src="{PUBLIC_APIURL}/assets/{secondary_logo}?fit=cover&width={desktop_logo_width}&height={desktop_logo_height}"
+						alt="UP"
+						class="mr-1 hidden h-12 w-12 max-w-xs rounded-full bg-secondary lg:block"
+					/>
+				{/if}
 			</a>
 			<a href="/">
-				<img
-					src="{PUBLIC_APIURL}/assets/{primary_logo}?fit=cover&width=90&height=90"
-					alt="DCS"
-					class="mr-2 h-10 w-10 max-w-xs rounded-full bg-secondary lg:mr-3 lg:h-12 lg:w-12"
-				/>
+				{#if desktop_logo_width && desktop_logo_height}
+					<img
+						src="{PUBLIC_APIURL}/assets/{primary_logo}?fit=cover&width={desktop_logo_width}&height={desktop_logo_height}"
+						alt="DCS"
+						class="mr-2 h-10 w-10 max-w-xs rounded-full bg-secondary lg:mr-3 lg:h-12 lg:w-12"
+					/>
+				{/if}
 			</a>
 			<a href="/" class="font-semibold text-primary">
 				<h1 class="mt-[1px] text-[11px] lg:text-sm">University of the Philippines Diliman</h1>
@@ -178,20 +190,27 @@
 >
 	<nav class="w-full">
 		<!-- Favicons -->
-		<div class="mt-5 flex items-center justify-center lg:hidden">
+		<div
+			class="mt-5 flex items-center justify-center lg:hidden"
+			bind:clientHeight={mobile_logo_height}
+		>
 			<a href="/">
-				<img
-					src="{PUBLIC_APIURL}/assets/{primary_logo}?fit=cover&width=90&height=90"
-					alt="UP"
-					class="mr-1 hidden h-12 w-12 max-w-xs rounded-full bg-secondary lg:block"
-				/>
+				{#if mobile_logo_width && mobile_logo_height}
+					<img
+						src="{PUBLIC_APIURL}/assets/{primary_logo}?fit=cover&width={mobile_logo_width}&height={mobile_logo_height}"
+						alt="UP"
+						class="mr-1 hidden h-12 w-12 max-w-xs rounded-full bg-secondary lg:block"
+					/>
+				{/if}
 			</a>
 			<a href={secondary_logo_link ? secondary_logo_link : undefined} target="_blank">
-				<img
-					src="{PUBLIC_APIURL}/assets/{secondary_logo}?fit=cover&width=90&height=90"
-					alt="DCS"
-					class="mr-2 h-10 w-10 max-w-xs rounded-full bg-secondary lg:mr-3 lg:h-12 lg:w-12"
-				/>
+				{#if mobile_logo_width && mobile_logo_height}
+					<img
+						src="{PUBLIC_APIURL}/assets/{secondary_logo}?fit=cover&width={mobile_logo_width}&height={mobile_logo_height}"
+						alt="DCS"
+						class="mr-2 h-10 w-10 max-w-xs rounded-full bg-secondary lg:mr-3 lg:h-12 lg:w-12"
+					/>
+				{/if}
 			</a>
 			<div class="font-medium">
 				<h1 class="text-xs lg:text-sm">University of the Philippines Diliman</h1>

--- a/website-frontend/src/lib/components/nav/NavList.svelte
+++ b/website-frontend/src/lib/components/nav/NavList.svelte
@@ -42,7 +42,7 @@
 			href="/academics/{academics_category.slug}"
 			to={academics_category.name ?? `Academics Category ${i}`}
 			dropdown={true}
-			position="left-36 top-0"
+			position="top-0 left-full"
 		>
 			{#each academics_programs.filter(({ category }) => {
 				if (typeof category !== 'string') return category?.slug == academics_category.slug;
@@ -69,7 +69,7 @@
 </NavItem>
 <NavItem href="/research" to="Research" dropdown={true}>
 	<NavItem href="/research" to="Overview" />
-	<NavItem href="/research/labs" to="Laboratories" dropdown={true} position="left-32 top-0">
+	<NavItem href="/research/labs" to="Laboratories" dropdown={true} position="top-0 left-full">
 		{#each laboratories as laboratory, i}
 			<NavItem href="/research/labs/{laboratory.slug}" to={laboratory.name ?? `Laboratory ${i}`} />
 		{/each}
@@ -86,4 +86,4 @@
 	{/each}
 </NavItem>
 <NavItem href="/alumni" to="Alumni" />
-<NavItem href="/partnerships" to="Partnerships" position="md:right-0 lg:left-0" />
+<NavItem href="/partnerships" to="Partnerships" />

--- a/website-frontend/src/lib/components/search/SearchResult.svelte
+++ b/website-frontend/src/lib/components/search/SearchResult.svelte
@@ -20,6 +20,9 @@
 					.filter((tag) => typeof tag !== 'undefined')
 			: []
 		: [];
+
+	let pubs_banner_height: number;
+	let general_banner_height: number;
 </script>
 
 {#if !publication}
@@ -30,10 +33,11 @@
 		>
 			<div
 				class="flex h-36 w-full items-center justify-center overflow-hidden rounded-lg p-2 shadow-none sm:h-60 lg:h-96"
+				bind:clientHeight={general_banner_height}
 			>
-				{#if image}
+				{#if image && general_banner_height}
 					<img
-						src="{PUBLIC_APIURL}/assets/{image}?height=360"
+						src="{PUBLIC_APIURL}/assets/{image}?height={general_banner_height}"
 						alt={name}
 						class="max-h-full max-w-full rounded-lg"
 					/>
@@ -54,10 +58,11 @@
 			>
 				<div
 					class="flex h-36 w-full items-center justify-center overflow-hidden rounded-lg p-2 shadow-none sm:h-60 lg:h-96"
+					bind:clientHeight={pubs_banner_height}
 				>
-					{#if image}
+					{#if image && pubs_banner_height}
 						<img
-							src="{PUBLIC_APIURL}/assets/{image}?height=360"
+							src="{PUBLIC_APIURL}/assets/{image}?height={pubs_banner_height}"
 							alt={name}
 							class="max-h-full max-w-full rounded-lg"
 						/>

--- a/website-frontend/src/lib/components/table/Calendar.svelte
+++ b/website-frontend/src/lib/components/table/Calendar.svelte
@@ -7,6 +7,8 @@
 
 	export let events: Events;
 
+	let hero_image_height: number;
+
 	let currentMonth = new Date().getMonth();
 	let currentYear = new Date().getFullYear();
 
@@ -130,23 +132,25 @@
 							>
 								<Card class="p-3">
 									<div class="flex flex-col gap-3 md:flex-row md:items-center md:gap-5">
-										{#if event.hero_image}
-											<div class="h-48 w-full overflow-hidden rounded-lg md:h-36 md:w-52">
-												<img
-													src="{PUBLIC_APIURL}/assets/{event.hero_image}?height=360"
-													alt={event.event_headline}
-													class="h-full w-full object-cover"
-												/>
-											</div>
-										{:else}
-											<div
-												class="flex h-48 w-full items-center justify-center rounded-lg border border-slate-300 bg-slate-200 md:h-36 md:w-52"
-											>
-												<div class="text-slate-400">
-													<Image class="h-8 w-8" />
+										<div bind:clientHeight={hero_image_height}>
+											{#if event.hero_image && hero_image_height}
+												<div class="h-48 w-full overflow-hidden rounded-lg md:h-36 md:w-52">
+													<img
+														src="{PUBLIC_APIURL}/assets/{event.hero_image}?height={hero_image_height}"
+														alt={event.event_headline}
+														class="h-full w-full object-cover"
+													/>
 												</div>
-											</div>
-										{/if}
+											{:else}
+												<div
+													class="flex h-48 w-full items-center justify-center rounded-lg border border-slate-300 bg-slate-200 md:h-36 md:w-52"
+												>
+													<div class="text-slate-400">
+														<Image class="h-8 w-8" />
+													</div>
+												</div>
+											{/if}
+										</div>
 
 										<div class="flex-1">
 											<div class="mb-1 flex flex-wrap gap-1">

--- a/website-frontend/src/routes/+layout.svelte
+++ b/website-frontend/src/routes/+layout.svelte
@@ -12,6 +12,8 @@
 
 	let marginType = 'default';
 
+	$: $reloading = false;
+
 	$: {
 		if ($page.url.pathname === '/') {
 			marginType = 'wide';

--- a/website-frontend/src/routes/news/[slug]/+page.svelte
+++ b/website-frontend/src/routes/news/[slug]/+page.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	/** @type {import('./$types').PageData} */
 	import NewsCard from '$lib/components/cards/NewsCard.svelte';
 	import { PUBLIC_APIURL } from '$env/static/public';
@@ -7,6 +7,7 @@
 	import FullWidthBreakout from '$lib/components/FullWidthBreakout.svelte';
 	import Share from '$lib/components/buttons/Share.svelte';
 	export let data;
+	let banner_height: number;
 
 	$: ({ link, other_news, news_item } = data);
 
@@ -40,15 +41,15 @@
 				<Breadcrumb page_name={news_item.title} />
 			</div>
 
-			{#if news_item.background_image}
-				<div class="h-full px-5">
+			<div class="h-[40svh] px-5 md:h-[60svh]" bind:clientHeight={banner_height}>
+				{#if news_item.background_image && banner_height}
 					<img
 						class="h-[40svh] w-full object-cover md:h-[60svh]"
-						src="{PUBLIC_APIURL}/assets/{news_item.background_image}?height=720"
+						src="{PUBLIC_APIURL}/assets/{news_item.background_image}?height={banner_height}"
 						alt="Background"
 					/>
-				</div>
-			{/if}
+				{/if}
+			</div>
 			<div
 				class="mx-auto flex w-full max-w-[1220px] flex-col gap-y-5 px-8 pb-16 md:px-16 2xl:max-w-screen-2xl"
 				class:mt-8={news_item.background_image}


### PR DESCRIPTION
This PR addresses the following:
* Use dynamic resolution for fetching images in the Directus CMS using Svelte's dimensional bindings (`clientHeight` and `clientWidth`) _except_ for small logos.
* Fix infinite loading screen during back navigation by _always_ setting `$reloading` to `false` in the global `+layout.svelte` script.
* Use `left-full` to align nested dropdown elements in the navigation bar for `academics/[category]/[slug]` and `research/labs/[slug]`.